### PR TITLE
Add RLHF PPO trainer features and example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,82 @@
 # NovaRL
+
+NovaRL is a lightweight reinforcement learning sandbox focused on reinforcement learning from human feedback (RLHF) experiments. The codebase favors clarity over completeness so that individual components such as rollout engines, buffers, and trainers can be understood and customized quickly.
+
+## Key features
+
+- **Composable interfaces** for environments, rollout engines, trainers, buffers, and reward managers.
+- **Synchronous PPO implementation** supporting both clipping and KL-penalty modes.
+- **Reference model utilities** for RLHF stabilization, including automatic frozen copies and optional weight-tied references.
+- **Simple timing, logging, and checkpoint helpers** to make toy experiments easy to reproduce.
+- **Examples that run in minutes**, including a tiny single-turn RLHF set-up.
+
+## Getting started
+
+NovaRL targets Python 3.10+ and PyTorch 2.x. Clone the repository and install it in editable mode:
+
+```bash
+pip install -e .
+```
+
+### Running the toy PPO example
+
+The classic control-style PPO loop used for sanity checks lives in [`examples/minimal_ppo_sync.py`](examples/minimal_ppo_sync.py). Launch it with:
+
+```bash
+PYTHONPATH=. python examples/minimal_ppo_sync.py
+```
+
+The script trains a tiny feed-forward policy on a synthetic prompt environment and logs reward, KL divergence, entropy, and throughput.
+
+### RLHF single-turn PPO example
+
+The RLHF-focused demo in [`examples/ppo_rlhf_single_turn.py`](examples/ppo_rlhf_single_turn.py) shows how to stabilize PPO with a KL penalty against a frozen reference model:
+
+```bash
+PYTHONPATH=. python examples/ppo_rlhf_single_turn.py
+```
+
+The example:
+
+1. Builds a four-prompt preference dataset with deterministic per-action rewards.
+2. Creates a `SingleTurnPreferenceEnvironment` that serves prompts in batches.
+3. Runs PPO with clipping, entropy regularization, and a KL penalty against a frozen reference model.
+4. Adapts the KL coefficient online to keep divergence within a configurable target window.
+5. Logs training metrics including objective value, KL divergences, entropy, and episodes/sec.
+6. Saves model and optimizer checkpoints under `checkpoints/ppo_rlhf_single_turn/` and prints the learned action probabilities for each prompt.
+
+Because the environment’s episodes last a single step, the script demonstrates how KL regularization can improve rewards without unstable spikes.
+
+## PPO trainer overview
+
+`algos/ppo/trainer.py` contains the core PPO logic. The trainer accepts optional knobs that are common in RLHF research:
+
+- `clip_range`: enables the standard PPO clipping objective when set to a positive value.
+- `kl_coef`: scales a KL penalty computed against a reference policy. Set to zero to disable.
+- `adaptive_kl`: toggles automatic adjustment of the KL coefficient. The coefficient increases when the KL exceeds `kl_target * 1.5` and decreases when it drops below `kl_target / 1.5`.
+- `reference_model`: pass `"copy"` (default) to create a frozen snapshot, `"tie"` to reuse the policy weights lazily, or provide a custom `nn.Module`.
+
+The trainer logs additional diagnostics such as the unclipped policy objective, KL penalty magnitude, and the KL divergence to both the previous policy (`kl`) and the reference policy (`kl_to_ref`).
+
+## Project structure
+
+```
+algos/          # Training algorithms (PPO)
+core/           # Shared abstractions, data structures, and utilities
+engines/        # Rollout engines (synchronous loops and vLLM adapters)
+envs/           # Toy prompt environments and preference datasets
+examples/       # Executable training scripts
+rewards/        # Reward managers for transforming environment signals
+```
+
+## Testing
+
+NovaRL ships with unit tests under `tests/`. Run them with:
+
+```bash
+pytest
+```
+
+## Contributing
+
+Contributions are welcome! Feel free to open issues or pull requests that improve documentation, add environments, or extend the PPO trainer.

--- a/algos/ppo/__init__.py
+++ b/algos/ppo/__init__.py
@@ -1,0 +1,5 @@
+"""Proximal Policy Optimization (PPO) algorithms."""
+
+from .trainer import PPOTrainer
+
+__all__ = ["PPOTrainer"]

--- a/algos/ppo/trainer.py
+++ b/algos/ppo/trainer.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from typing import Mapping
+import copy
+from typing import Mapping, Optional, Union
 
 import torch
 from torch import nn
@@ -22,6 +23,11 @@ class PPOTrainer(Trainer):
         value_coef: float = 0.5,
         entropy_coef: float = 0.01,
         max_grad_norm: float = 1.0,
+        kl_coef: float = 0.0,
+        adaptive_kl: bool = False,
+        kl_target: float = 0.01,
+        kl_adaptation_speed: float = 1.5,
+        reference_model: Optional[Union[nn.Module, str]] = None,
     ) -> None:
         self.policy = policy
         self.optimizer = optimizer
@@ -29,6 +35,12 @@ class PPOTrainer(Trainer):
         self.value_coef = value_coef
         self.entropy_coef = entropy_coef
         self.max_grad_norm = max_grad_norm
+        self.kl_coef = kl_coef
+        self.adaptive_kl = adaptive_kl
+        self.kl_target = kl_target
+        self.kl_adaptation_speed = kl_adaptation_speed
+
+        self.reference_model = self._setup_reference_model(reference_model)
 
     def step(self, batch: TrajectoryBatch) -> Mapping[str, float]:
         self.policy.train()
@@ -50,11 +62,29 @@ class PPOTrainer(Trainer):
 
         ratio = torch.exp(log_probs - old_log_probs)
         surr1 = ratio * advantages
-        surr2 = torch.clamp(ratio, 1.0 - self.clip_range, 1.0 + self.clip_range) * advantages
-        policy_loss = -torch.min(surr1, surr2).mean()
+        if self.clip_range is not None and self.clip_range > 0:
+            clipped_ratio = torch.clamp(ratio, 1.0 - self.clip_range, 1.0 + self.clip_range)
+            surr2 = clipped_ratio * advantages
+            pg_objective = torch.min(surr1, surr2)
+            clip_fraction = (torch.abs(ratio - 1.0) > self.clip_range).float().mean()
+        else:
+            pg_objective = surr1
+            clip_fraction = torch.tensor(0.0, device=pg_objective.device)
+        policy_loss = -pg_objective.mean()
 
         value_loss = F.mse_loss(values, returns)
-        loss = policy_loss + self.value_coef * value_loss - self.entropy_coef * entropy
+        kl_penalty = torch.tensor(0.0, device=observations.device)
+        ref_kl = torch.tensor(0.0, device=observations.device)
+        if self.reference_model is not None:
+            with torch.no_grad():
+                ref_outputs = self.reference_model(observations)
+                ref_logits = ref_outputs["logits"]
+            ref_dist = Categorical(logits=ref_logits)
+            ref_kl = torch.distributions.kl_divergence(dist, ref_dist).mean()
+            if self.kl_coef > 0:
+                kl_penalty = self.kl_coef * ref_kl
+
+        loss = policy_loss + self.value_coef * value_loss + kl_penalty - self.entropy_coef * entropy
 
         self.optimizer.zero_grad()
         loss.backward()
@@ -63,7 +93,9 @@ class PPOTrainer(Trainer):
         self.optimizer.step()
 
         approx_kl = torch.mean(old_log_probs - log_probs).clamp_min(0).item()
-        clip_fraction = (torch.abs(ratio - 1.0) > self.clip_range).float().mean().item()
+        if self.adaptive_kl and self.reference_model is not None and ref_kl.item() > 0:
+            self._update_kl_coef(float(ref_kl.item()))
+        clip_fraction_value = float(clip_fraction.item())
 
         metrics = {
             "loss": float(loss.item()),
@@ -71,10 +103,49 @@ class PPOTrainer(Trainer):
             "value_loss": float(value_loss.item()),
             "entropy": float(entropy.item()),
             "kl": float(approx_kl),
-            "clip_fraction": float(clip_fraction),
+            "policy_objective": float(pg_objective.mean().item()),
+            "kl_to_ref": float(ref_kl.item()),
+            "kl_coef": float(self.kl_coef),
+            "kl_penalty": float(kl_penalty.item()),
+            "clip_fraction": clip_fraction_value,
             "reward_mean": float(flat.rewards.mean().item()),
         }
         return metrics
+
+    def _setup_reference_model(
+        self, reference_model: Optional[Union[nn.Module, str]]
+    ) -> Optional[nn.Module]:
+        if isinstance(reference_model, str):
+            mode = reference_model.lower()
+            if mode == "tie":
+                return self.policy
+            if mode not in {"copy", "auto"}:
+                raise ValueError(
+                    "reference_model string must be 'copy', 'tie', or 'auto'"
+                )
+            reference_model = None
+        if reference_model is None:
+            if self.kl_coef == 0 and not self.adaptive_kl:
+                return None
+            reference_model = copy.deepcopy(self.policy)
+        if reference_model is self.policy:
+            return reference_model
+        for param in reference_model.parameters():
+            param.requires_grad_(False)
+        reference_model.eval()
+        params = list(self.policy.parameters())
+        if params:
+            reference_model.to(params[0].device)
+        return reference_model
+
+    def _update_kl_coef(self, kl_value: float) -> None:
+        if self.kl_target <= 0:
+            return
+        if kl_value > self.kl_target * 1.5:
+            self.kl_coef *= self.kl_adaptation_speed
+        elif kl_value < self.kl_target / 1.5:
+            self.kl_coef /= self.kl_adaptation_speed
+
 
 
 __all__ = ["PPOTrainer"]

--- a/envs/__init__.py
+++ b/envs/__init__.py
@@ -1,5 +1,10 @@
 """Environment implementations."""
 
+from .prompt.single_turn import PreferenceDataset, SingleTurnPreferenceEnvironment
 from .prompt.toy import ToyPromptEnvironment
 
-__all__ = ["ToyPromptEnvironment"]
+__all__ = [
+    "PreferenceDataset",
+    "SingleTurnPreferenceEnvironment",
+    "ToyPromptEnvironment",
+]

--- a/envs/prompt/__init__.py
+++ b/envs/prompt/__init__.py
@@ -1,5 +1,10 @@
 """Prompt-based environments."""
 
+from .single_turn import PreferenceDataset, SingleTurnPreferenceEnvironment
 from .toy import ToyPromptEnvironment
 
-__all__ = ["ToyPromptEnvironment"]
+__all__ = [
+    "PreferenceDataset",
+    "SingleTurnPreferenceEnvironment",
+    "ToyPromptEnvironment",
+]

--- a/envs/prompt/single_turn.py
+++ b/envs/prompt/single_turn.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Sequence
+
+import torch
+
+from core.interfaces import EnvStep
+from envs.base import BatchedEnvironment
+
+
+@dataclass
+class PreferenceDataset:
+    """Container holding prompt features and action rewards."""
+
+    prompt_features: torch.Tensor
+    action_rewards: torch.Tensor
+    prompt_texts: Sequence[str] | None = None
+
+    def __post_init__(self) -> None:
+        if self.prompt_features.dim() != 2:
+            raise ValueError("prompt_features must be a 2D tensor")
+        if self.action_rewards.dim() != 2:
+            raise ValueError("action_rewards must be a 2D tensor")
+        if self.prompt_features.shape[0] != self.action_rewards.shape[0]:
+            raise ValueError("Dataset must have matching number of prompts")
+
+    @property
+    def num_prompts(self) -> int:
+        return int(self.prompt_features.shape[0])
+
+    @property
+    def observation_dim(self) -> int:
+        return int(self.prompt_features.shape[1])
+
+    @property
+    def action_dim(self) -> int:
+        return int(self.action_rewards.shape[1])
+
+
+class SingleTurnPreferenceEnvironment(BatchedEnvironment):
+    """Environment that samples prompts and rewards single actions.
+
+    Each episode consists of a single action. After an action is taken, a new
+    prompt is sampled for the subsequent observation so rollouts can continue
+    without explicit resets.
+    """
+
+    def __init__(
+        self,
+        dataset: PreferenceDataset,
+        batch_size: int,
+        device: torch.device | None = None,
+    ) -> None:
+        super().__init__(batch_size=batch_size, device=device)
+        self.dataset = dataset
+        self.prompt_features = dataset.prompt_features.to(self.device)
+        self.action_rewards = dataset.action_rewards.to(self.device)
+        self.prompt_texts = dataset.prompt_texts
+        self.current_indices = torch.zeros(batch_size, dtype=torch.long, device=self.device)
+        self._sample_indices()
+
+    def reset(self, batch_size: int | None = None) -> EnvStep:
+        if batch_size is not None and batch_size != self.batch_size:
+            raise ValueError("SingleTurnPreferenceEnvironment has fixed batch size")
+        self._sample_indices()
+        observations = self.prompt_features[self.current_indices]
+        zeros = torch.zeros(self.batch_size, device=self.device)
+        infos: Sequence[dict[str, float]] = tuple(
+            {"prompt_index": int(idx)} for idx in self.current_indices
+        )
+        return EnvStep(observations=observations, rewards=zeros, dones=zeros, infos=infos)
+
+    def step(self, actions: torch.Tensor) -> EnvStep:
+        if actions.shape[0] != self.batch_size:
+            raise ValueError("Action batch size mismatch")
+        if actions.dim() != 1:
+            actions = actions.squeeze(-1)
+        actions = actions.long()
+        if torch.any(actions < 0) or torch.any(actions >= self.dataset.action_dim):
+            raise ValueError("Action index out of bounds for preference dataset")
+        prompt_indices = self.current_indices
+        rewards = self.action_rewards[prompt_indices, actions]
+        dones = torch.ones(self.batch_size, device=self.device)
+        infos: Sequence[dict[str, float]] = tuple(
+            {
+                "prompt_index": int(p.item()),
+                "action": int(a.item()),
+                "reward": float(r.item()),
+            }
+            for p, a, r in zip(prompt_indices, actions, rewards)
+        )
+        self._sample_indices()
+        next_obs = self.prompt_features[self.current_indices]
+        return EnvStep(observations=next_obs, rewards=rewards, dones=dones, infos=infos)
+
+    def _sample_indices(self) -> None:
+        self.current_indices = torch.randint(
+            0, self.dataset.num_prompts, (self.batch_size,), device=self.device
+        )
+
+
+__all__ = ["PreferenceDataset", "SingleTurnPreferenceEnvironment"]

--- a/examples/ppo_rlhf_single_turn.py
+++ b/examples/ppo_rlhf_single_turn.py
@@ -1,0 +1,170 @@
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Sequence
+
+import torch
+from torch import nn
+
+from algos.ppo.trainer import PPOTrainer
+from core.buffers.memory import TrajectoryBuffer
+from core.utils.timing import RateTracker
+from engines.sync.sync_engine import SynchronousRolloutEngine
+from envs.prompt.single_turn import PreferenceDataset, SingleTurnPreferenceEnvironment
+from rewards.fake.basic import IdentityRewardManager
+
+logging.basicConfig(level=logging.INFO, format="[%(levelname)s] %(message)s")
+
+
+@dataclass
+class ExperimentConfig:
+    batch_size: int = 8
+    horizon: int = 1
+    total_iterations: int = 80
+    learning_rate: float = 3e-4
+    clip_range: float | None = 0.2
+    kl_coef: float = 0.05
+    adaptive_kl: bool = True
+    kl_target: float = 0.02
+    kl_adaptation_speed: float = 1.5
+    entropy_coef: float = 0.01
+    value_coef: float = 0.5
+    checkpoint_dir: str = "checkpoints/ppo_rlhf_single_turn"
+
+
+class TinyPreferencePolicy(nn.Module):
+    def __init__(self, observation_dim: int, action_dim: int, hidden_size: int = 64) -> None:
+        super().__init__()
+        self.encoder = nn.Sequential(
+            nn.Linear(observation_dim, hidden_size),
+            nn.Tanh(),
+            nn.Linear(hidden_size, hidden_size),
+            nn.Tanh(),
+        )
+        self.policy_head = nn.Linear(hidden_size, action_dim)
+        self.value_head = nn.Linear(hidden_size, 1)
+
+    def forward(self, observations: torch.Tensor) -> dict[str, torch.Tensor]:
+        x = self.encoder(observations)
+        logits = self.policy_head(x)
+        value = self.value_head(x)
+        return {"logits": logits, "value": value}
+
+
+def build_tiny_dataset() -> PreferenceDataset:
+    prompt_features = torch.tensor(
+        [
+            [1.0, 0.0, 0.0, 0.2, -0.3, 0.1],
+            [0.0, 1.0, 0.0, -0.4, 0.3, 0.2],
+            [0.0, 0.0, 1.0, 0.3, 0.1, -0.2],
+            [0.5, 0.5, 0.0, -0.1, 0.2, 0.4],
+        ],
+        dtype=torch.float32,
+    )
+    action_rewards = torch.tensor(
+        [
+            [1.2, 0.0, -0.5],
+            [0.0, 1.1, -0.6],
+            [0.6, -0.2, 1.0],
+            [-0.1, 0.4, 0.9],
+        ],
+        dtype=torch.float32,
+    )
+    prompt_texts: Sequence[str] = (
+        "Prefer action 0",
+        "Prefer action 1",
+        "Action 2 wins",
+        "Action 2 slightly better",
+    )
+    return PreferenceDataset(prompt_features=prompt_features, action_rewards=action_rewards, prompt_texts=prompt_texts)
+
+
+def main(cfg: ExperimentConfig | None = None) -> None:
+    cfg = cfg or ExperimentConfig()
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    torch.manual_seed(1234)
+    if torch.cuda.is_available():
+        torch.cuda.manual_seed_all(1234)
+    dataset = build_tiny_dataset()
+
+    env = SingleTurnPreferenceEnvironment(dataset=dataset, batch_size=cfg.batch_size, device=device)
+    policy = TinyPreferencePolicy(dataset.observation_dim, dataset.action_dim).to(device)
+    optimizer = torch.optim.Adam(policy.parameters(), lr=cfg.learning_rate)
+
+    reward_manager = IdentityRewardManager()
+    rollout_engine = SynchronousRolloutEngine(
+        env=env,
+        policy=policy,
+        reward_manager=reward_manager,
+        horizon=cfg.horizon,
+    )
+    buffer = TrajectoryBuffer(capacity=4)
+    trainer = PPOTrainer(
+        policy=policy,
+        optimizer=optimizer,
+        clip_range=cfg.clip_range,
+        value_coef=cfg.value_coef,
+        entropy_coef=cfg.entropy_coef,
+        kl_coef=cfg.kl_coef,
+        adaptive_kl=cfg.adaptive_kl,
+        kl_target=cfg.kl_target,
+        kl_adaptation_speed=cfg.kl_adaptation_speed,
+        reference_model="copy",
+    )
+    rate_tracker = RateTracker(window_seconds=30.0)
+
+    total_episodes = 0
+    for iteration in range(cfg.total_iterations):
+        trajectories = rollout_engine.generate()
+        buffer.put(trajectories)
+        batch = buffer.get()
+        metrics = trainer.step(batch)
+        completed = trajectories.completed_episodes()
+        total_episodes += completed
+        rate_tracker.update(completed)
+        eps_per_sec = rate_tracker.rate()
+        logging.info(
+            (
+                "iter=%d reward=%.3f obj=%.4f kl_old=%.4f kl_ref=%.4f kl_coef=%.4f "
+                "entropy=%.3f eps/s=%.2f"
+            ),
+            iteration,
+            metrics["reward_mean"],
+            metrics["policy_objective"],
+            metrics["kl"],
+            metrics["kl_to_ref"],
+            metrics["kl_coef"],
+            metrics["entropy"],
+            eps_per_sec,
+        )
+
+    checkpoint_dir = Path(cfg.checkpoint_dir)
+    checkpoint_dir.mkdir(parents=True, exist_ok=True)
+    policy_path = checkpoint_dir / "policy.pt"
+    optimizer_path = checkpoint_dir / "optimizer.pt"
+    torch.save({"model_state_dict": policy.state_dict()}, policy_path)
+    torch.save({"optimizer_state_dict": optimizer.state_dict()}, optimizer_path)
+    logging.info("Saved policy checkpoint to %s", policy_path)
+    logging.info("Saved optimizer checkpoint to %s", optimizer_path)
+
+    policy.eval()
+    with torch.no_grad():
+        logits = policy(dataset.prompt_features.to(device))["logits"]
+        probs = logits.softmax(dim=-1).cpu()
+    labels: Sequence[str]
+    if dataset.prompt_texts is not None:
+        labels = dataset.prompt_texts
+    else:
+        labels = [f"prompt_{i}" for i in range(len(probs))]
+    for text, prob in zip(labels, probs):
+        logging.info("prompt=%s probs=%s", text, [round(p.item(), 3) for p in prob])
+
+    logging.info(
+        "Finished training %d iterations over %d episodes", cfg.total_iterations, total_episodes
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- extend the PPO trainer with KL penalty support, reference model handling, and adaptive KL logging for RLHF workflows
- add a reusable single-turn preference environment and a tiny RLHF PPO example that checkpoints policy and optimizer state
- document the workflow in the README and relax trajectory batch shape validation for flattened data

## Testing
- `pytest`
- `PYTHONPATH=. python examples/ppo_rlhf_single_turn.py`


------
https://chatgpt.com/codex/tasks/task_e_68ccd94e1dc48332ad9e367192419c8c