### PR TITLE
Add verifiable reward manager and RLVR examples

### DIFF
--- a/envs/prompt/__init__.py
+++ b/envs/prompt/__init__.py
@@ -2,9 +2,12 @@
 
 from .single_turn import PreferenceDataset, SingleTurnPreferenceEnvironment
 from .toy import ToyPromptEnvironment
+from .verifiable import VerifiablePromptDataset, VerifiablePromptEnvironment
 
 __all__ = [
     "PreferenceDataset",
     "SingleTurnPreferenceEnvironment",
     "ToyPromptEnvironment",
+    "VerifiablePromptDataset",
+    "VerifiablePromptEnvironment",
 ]

--- a/envs/prompt/verifiable.py
+++ b/envs/prompt/verifiable.py
@@ -1,0 +1,119 @@
+"""Prompt environment that surfaces verifiable reward metadata."""
+
+from __future__ import annotations
+
+import copy
+from dataclasses import dataclass
+from typing import Mapping, MutableMapping, Sequence
+
+import torch
+
+from core.interfaces import EnvStep
+from envs.base import BatchedEnvironment
+
+
+@dataclass
+class VerifiablePromptDataset:
+    """Container describing prompts with candidate completions and metadata."""
+
+    prompt_features: torch.Tensor
+    completions: Sequence[Sequence[str]]
+    prompt_texts: Sequence[str]
+    metadata: Sequence[Mapping[str, object]]
+
+    def __post_init__(self) -> None:
+        if self.prompt_features.dim() != 2:
+            raise ValueError("prompt_features must be a 2D tensor")
+        num_prompts = self.prompt_features.shape[0]
+        if len(self.completions) != num_prompts:
+            raise ValueError("completions must match number of prompts")
+        if len(self.prompt_texts) != num_prompts:
+            raise ValueError("prompt_texts must match number of prompts")
+        if len(self.metadata) != num_prompts:
+            raise ValueError("metadata must match number of prompts")
+        lengths = {len(options) for options in self.completions}
+        if not lengths:
+            raise ValueError("Dataset must contain at least one prompt")
+        if len(lengths) != 1:
+            raise ValueError("All prompts must have the same number of completions")
+
+    @property
+    def num_prompts(self) -> int:
+        return int(self.prompt_features.shape[0])
+
+    @property
+    def observation_dim(self) -> int:
+        return int(self.prompt_features.shape[1])
+
+    @property
+    def action_dim(self) -> int:
+        return len(self.completions[0])
+
+
+class VerifiablePromptEnvironment(BatchedEnvironment):
+    """Batched environment that defers reward computation to verifiers."""
+
+    def __init__(
+        self,
+        dataset: VerifiablePromptDataset,
+        batch_size: int,
+        *,
+        device: torch.device | None = None,
+    ) -> None:
+        super().__init__(batch_size=batch_size, device=device)
+        self.dataset = dataset
+        self.prompt_features = dataset.prompt_features.to(self.device)
+        self.current_indices = torch.zeros(batch_size, dtype=torch.long, device=self.device)
+        self._sample_indices()
+
+    def reset(self, batch_size: int | None = None) -> EnvStep:
+        if batch_size is not None and batch_size != self.batch_size:
+            raise ValueError("VerifiablePromptEnvironment has fixed batch size")
+        self._sample_indices()
+        observations = self.prompt_features[self.current_indices]
+        zeros = torch.zeros(self.batch_size, device=self.device)
+        infos: Sequence[MutableMapping[str, object]] = tuple(
+            self._make_info(idx, None) for idx in self.current_indices
+        )
+        return EnvStep(observations=observations, rewards=zeros, dones=zeros, infos=infos)
+
+    def step(self, actions: torch.Tensor) -> EnvStep:
+        if actions.shape[0] != self.batch_size:
+            raise ValueError("Action batch size mismatch")
+        actions = actions.long().view(-1)
+        if torch.any(actions < 0) or torch.any(actions >= self.dataset.action_dim):
+            raise ValueError("Action index out of bounds for verifiable dataset")
+        prompt_indices = self.current_indices
+        infos: Sequence[MutableMapping[str, object]] = tuple(
+            self._make_info(int(p.item()), int(a.item()))
+            for p, a in zip(prompt_indices, actions)
+        )
+        rewards = torch.zeros(self.batch_size, device=self.device)
+        dones = torch.ones(self.batch_size, device=self.device)
+        self._sample_indices()
+        next_obs = self.prompt_features[self.current_indices]
+        return EnvStep(observations=next_obs, rewards=rewards, dones=dones, infos=infos)
+
+    def _make_info(
+        self, prompt_index: int, action: int | None
+    ) -> MutableMapping[str, object]:
+        base: MutableMapping[str, object] = {
+            "prompt_index": prompt_index,
+            "prompt": self.dataset.prompt_texts[prompt_index],
+        }
+        meta = copy.deepcopy(self.dataset.metadata[prompt_index])
+        if action is not None:
+            completion = self.dataset.completions[prompt_index][action]
+            base["completion_index"] = action
+            base["completion"] = completion
+        base.update(meta)
+        return base
+
+    def _sample_indices(self) -> None:
+        self.current_indices = torch.randint(
+            0, self.dataset.num_prompts, (self.batch_size,), device=self.device
+        )
+
+
+__all__ = ["VerifiablePromptDataset", "VerifiablePromptEnvironment"]
+

--- a/examples/rl_code.py
+++ b/examples/rl_code.py
@@ -1,0 +1,269 @@
+"""RLVR example that rewards code solutions via unit tests and learned signals."""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Callable, Sequence
+
+import torch
+from torch import nn
+
+from algos.ppo.trainer import PPOTrainer
+from core.buffers.memory import TrajectoryBuffer
+from core.utils.timing import RateTracker
+from engines.sync.sync_engine import SynchronousRolloutEngine
+from envs.prompt.verifiable import VerifiablePromptDataset, VerifiablePromptEnvironment
+from rewards.rlvr.manager import VerifiableRewardManager
+from rewards.rlvr.signals import HTTPRewardModelSignal, RegexMatchSignal, UnitTestSignal
+
+logging.basicConfig(level=logging.INFO, format="[%(levelname)s] %(message)s")
+
+
+@dataclass
+class ExperimentConfig:
+    batch_size: int = 4
+    horizon: int = 1
+    total_iterations: int = 80
+    learning_rate: float = 3e-4
+    clip_range: float | None = 0.2
+    entropy_coef: float = 0.02
+    value_coef: float = 0.6
+    kl_coef: float = 0.05
+    kl_target: float = 0.02
+    adaptive_kl: bool = True
+    kl_adaptation_speed: float = 1.5
+
+
+class TinyPolicy(nn.Module):
+    def __init__(self, observation_dim: int, action_dim: int, hidden_size: int = 96) -> None:
+        super().__init__()
+        self.encoder = nn.Sequential(
+            nn.Linear(observation_dim, hidden_size),
+            nn.Tanh(),
+            nn.Linear(hidden_size, hidden_size),
+            nn.Tanh(),
+        )
+        self.policy_head = nn.Linear(hidden_size, action_dim)
+        self.value_head = nn.Linear(hidden_size, 1)
+
+    def forward(self, observations: torch.Tensor) -> dict[str, torch.Tensor]:
+        x = self.encoder(observations)
+        logits = self.policy_head(x)
+        value = self.value_head(x)
+        return {"logits": logits, "value": value}
+
+
+def _length_prior_client(scale: float = 1.0) -> Callable[[dict[str, object]], Sequence[float]]:
+    def scorer(payload: dict[str, object]) -> list[float]:
+        completions = payload.get("completions", [])
+        scores: list[float] = []
+        for text in completions:
+            length = len(str(text))
+            score = max(0.0, 1.0 - (length / (200.0 * scale)))
+            scores.append(score)
+        return scores
+
+    return scorer
+
+
+def build_dataset() -> VerifiablePromptDataset:
+    prompts: Sequence[str] = (
+        "Implement solve(x: int) -> int that returns x squared.",
+        "Write solve(nums: list[int]) that returns the maximum element.",
+        "Create solve(n: int) that returns the sum of integers from 1 to n.",
+        "Write solve(words: list[str]) returning the concatenation separated by spaces.",
+    )
+    prompt_features = torch.eye(len(prompts), dtype=torch.float32)
+    completions: list[list[str]] = []
+    metadata: list[dict[str, object]] = []
+
+    # Candidate completions for each prompt (APPS-style multiple proposals).
+    completions.append(
+        [
+            "def solve(x):\n    return x * x\n",
+            "def solve(x):\n    return x + x\n",
+            "def solve(x):\n    return x ** 3\n",
+        ]
+    )
+    metadata.append(
+        {
+            "entry_point": "solve",
+            "tests": (
+                {"args": [2], "expected": 4},
+                {"args": [5], "expected": 25},
+            ),
+            "format_pattern": r"def\s+solve",
+        }
+    )
+
+    completions.append(
+        [
+            "def solve(nums):\n    return max(nums) if nums else None\n",
+            "def solve(nums):\n    return sum(nums)\n",
+            "def solve(nums):\n    return min(nums)\n",
+        ]
+    )
+    metadata.append(
+        {
+            "entry_point": "solve",
+            "tests": (
+                {"args": [[1, 4, 2]], "expected": 4},
+                {"args": [[-5, -2, -9]], "expected": -2},
+            ),
+            "format_pattern": r"def\s+solve",
+        }
+    )
+
+    completions.append(
+        [
+            "def solve(n):\n    return n * (n + 1) // 2\n",
+            "def solve(n):\n    total = 0\n    for i in range(n):\n        total += i\n    return total\n",
+            "def solve(n):\n    return n\n",
+        ]
+    )
+    metadata.append(
+        {
+            "entry_point": "solve",
+            "tests": (
+                {"args": [3], "expected": 6},
+                {"args": [1], "expected": 1},
+                {"args": [10], "expected": 55},
+            ),
+            "format_pattern": r"def\s+solve",
+        }
+    )
+
+    completions.append(
+        [
+            "def solve(words):\n    return ' '.join(words)\n",
+            "def solve(words):\n    return ''.join(words)\n",
+            "def solve(words):\n    return words[0] if words else ''\n",
+        ]
+    )
+    metadata.append(
+        {
+            "entry_point": "solve",
+            "tests": (
+                {"args": [["hello", "world"]], "expected": "hello world"},
+                {"args": [["Nova", "RL"]], "expected": "Nova RL"},
+            ),
+            "format_pattern": r"def\s+solve",
+        }
+    )
+
+    return VerifiablePromptDataset(
+        prompt_features=prompt_features,
+        completions=completions,
+        prompt_texts=prompts,
+        metadata=metadata,
+    )
+
+
+def build_reward_manager() -> VerifiableRewardManager:
+    signals = [
+        UnitTestSignal(
+            name="unit",
+            completion_key="completion",
+            tests_key="tests",
+            entry_point_key="entry_point",
+            success_reward=1.0,
+            failure_reward=0.0,
+            weight=1.0,
+        ),
+        RegexMatchSignal(
+            name="signature",
+            pattern_key="format_pattern",
+            completion_key="completion",
+            positive_reward=0.1,
+            negative_reward=0.0,
+            weight=0.3,
+        ),
+        HTTPRewardModelSignal(
+            name="length_prior",
+            endpoint="http://localhost:9999/reward",
+            completion_key="completion",
+            prompt_key="prompt",
+            client=_length_prior_client(scale=1.5),
+            weight=0.2,
+        ),
+    ]
+    return VerifiableRewardManager(signals=signals, normalize_weights=True)
+
+
+def main(cfg: ExperimentConfig | None = None) -> None:
+    cfg = cfg or ExperimentConfig()
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    torch.manual_seed(7)
+    if torch.cuda.is_available():
+        torch.cuda.manual_seed_all(7)
+
+    dataset = build_dataset()
+    env = VerifiablePromptEnvironment(dataset=dataset, batch_size=cfg.batch_size, device=device)
+    policy = TinyPolicy(dataset.observation_dim, dataset.action_dim).to(device)
+    optimizer = torch.optim.Adam(policy.parameters(), lr=cfg.learning_rate)
+
+    reward_manager = build_reward_manager()
+    rollout_engine = SynchronousRolloutEngine(
+        env=env,
+        policy=policy,
+        reward_manager=reward_manager,
+        horizon=cfg.horizon,
+    )
+    buffer = TrajectoryBuffer(capacity=4)
+    trainer = PPOTrainer(
+        policy=policy,
+        optimizer=optimizer,
+        clip_range=cfg.clip_range,
+        value_coef=cfg.value_coef,
+        entropy_coef=cfg.entropy_coef,
+        kl_coef=cfg.kl_coef,
+        adaptive_kl=cfg.adaptive_kl,
+        kl_target=cfg.kl_target,
+        kl_adaptation_speed=cfg.kl_adaptation_speed,
+        reference_model="copy",
+    )
+    rate_tracker = RateTracker(window_seconds=30.0)
+
+    total_episodes = 0
+    for iteration in range(cfg.total_iterations):
+        trajectories = rollout_engine.generate()
+        buffer.put(trajectories)
+        batch = buffer.get()
+        metrics = trainer.step(batch)
+        completed = trajectories.completed_episodes()
+        total_episodes += completed
+        rate_tracker.update(completed)
+        eps_per_sec = rate_tracker.rate()
+
+        signal_means = {
+            name: float(values.mean())
+            for name, values in reward_manager.latest_signal_values.items()
+        }
+        logging.info(
+            (
+                "iter=%d reward=%.3f obj=%.4f kl=%.4f kl_ref=%.4f entropy=%.3f eps/s=%.2f "
+                "signals=%s"
+            ),
+            iteration,
+            metrics["reward_mean"],
+            metrics["policy_objective"],
+            metrics["kl"],
+            metrics["kl_to_ref"],
+            metrics["entropy"],
+            eps_per_sec,
+            {k: round(v, 3) for k, v in signal_means.items()},
+        )
+        if iteration % 10 == 0 and reward_manager.latest_histograms:
+            for name, hist in reward_manager.latest_histograms.items():
+                if hist is None:
+                    continue
+                counts = [round(c, 2) for c in hist["counts"]]
+                logging.info("hist_%s=%s", name, counts)
+
+    logging.info("Finished RLVR code run over %d episodes", total_episodes)
+
+
+if __name__ == "__main__":  # pragma: no cover - example script
+    main()
+

--- a/examples/rlvr_math.py
+++ b/examples/rlvr_math.py
@@ -1,0 +1,196 @@
+"""Tiny RLVR example using synthetic GSM8K-style math prompts."""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Sequence
+
+import torch
+from torch import nn
+
+from algos.ppo.trainer import PPOTrainer
+from core.buffers.memory import TrajectoryBuffer
+from core.utils.timing import RateTracker
+from engines.sync.sync_engine import SynchronousRolloutEngine
+from envs.prompt.verifiable import VerifiablePromptDataset, VerifiablePromptEnvironment
+from rewards.rlvr.manager import VerifiableRewardManager
+from rewards.rlvr.signals import MathAnswerSignal, RegexMatchSignal
+
+logging.basicConfig(level=logging.INFO, format="[%(levelname)s] %(message)s")
+
+
+@dataclass
+class ExperimentConfig:
+    batch_size: int = 6
+    horizon: int = 1
+    total_iterations: int = 60
+    learning_rate: float = 5e-4
+    clip_range: float | None = 0.2
+    entropy_coef: float = 0.01
+    value_coef: float = 0.5
+    kl_coef: float = 0.05
+    kl_target: float = 0.02
+    adaptive_kl: bool = True
+    kl_adaptation_speed: float = 1.5
+
+
+class TinyPolicy(nn.Module):
+    def __init__(self, observation_dim: int, action_dim: int, hidden_size: int = 128) -> None:
+        super().__init__()
+        self.encoder = nn.Sequential(
+            nn.Linear(observation_dim, hidden_size),
+            nn.Tanh(),
+            nn.Linear(hidden_size, hidden_size),
+            nn.Tanh(),
+        )
+        self.policy_head = nn.Linear(hidden_size, action_dim)
+        self.value_head = nn.Linear(hidden_size, 1)
+
+    def forward(self, observations: torch.Tensor) -> dict[str, torch.Tensor]:
+        x = self.encoder(observations)
+        logits = self.policy_head(x)
+        value = self.value_head(x)
+        return {"logits": logits, "value": value}
+
+
+def build_dataset() -> VerifiablePromptDataset:
+    prompts: Sequence[str] = (
+        "Mia buys 3 apples and then 4 more. How many apples does she have in total?",
+        "A class of 5 students each solves 3 problems. How many problems were solved?",
+        "Sam had $12 and spent $7 on a book. How much money does he have now?",
+        "A jar contains 8 red marbles and 5 blue marbles. How many marbles are there?",
+        "Liam runs 400 meters every day for 6 days. What distance does he cover?",
+        "Two numbers add up to 15. If the first is 9, what is the second?",
+    )
+    num_prompts = len(prompts)
+    action_dim = 3
+    prompt_features = torch.eye(num_prompts, dtype=torch.float32)
+    completions: list[list[str]] = []
+    metadata: list[dict[str, object]] = []
+    answers = [7, 15, 5, 13, 2400, 6]
+    incorrect_templates = [
+        "We start by adding and end with the wrong value. Answer: {}",
+        "The student multiplies incorrectly. Answer: {}",
+        "Subtracting gives us a mistaken answer. Answer: {}",
+    ]
+    for idx, (prompt, answer) in enumerate(zip(prompts, answers)):
+        wrong = [answer + 2, max(answer - 3, 0), answer + 10]
+        texts = [
+            f"We add carefully. #### {answer}\nAnswer: {answer}",
+            incorrect_templates[idx % len(incorrect_templates)].format(wrong[0]),
+            f"Another try concludes with Answer: {wrong[1]}",
+        ]
+        completions.append(texts)
+        metadata.append(
+            {
+                "answer": float(answer),
+                "format_pattern": r"Answer:\s*-?\d+",
+            }
+        )
+    return VerifiablePromptDataset(
+        prompt_features=prompt_features,
+        completions=completions,
+        prompt_texts=prompts,
+        metadata=metadata,
+    )
+
+
+def build_reward_manager() -> VerifiableRewardManager:
+    signals = [
+        MathAnswerSignal(
+            name="math_exact",
+            answer_key="answer",
+            completion_key="completion",
+            correct_reward=1.0,
+            incorrect_reward=0.0,
+            weight=1.0,
+        ),
+        RegexMatchSignal(
+            name="format_bonus",
+            pattern_key="format_pattern",
+            completion_key="completion",
+            positive_reward=0.2,
+            negative_reward=0.0,
+            weight=0.5,
+        ),
+    ]
+    return VerifiableRewardManager(signals=signals, normalize_weights=True)
+
+
+def main(cfg: ExperimentConfig | None = None) -> None:
+    cfg = cfg or ExperimentConfig()
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    torch.manual_seed(2024)
+    if torch.cuda.is_available():
+        torch.cuda.manual_seed_all(2024)
+
+    dataset = build_dataset()
+    env = VerifiablePromptEnvironment(dataset=dataset, batch_size=cfg.batch_size, device=device)
+    policy = TinyPolicy(dataset.observation_dim, dataset.action_dim).to(device)
+    optimizer = torch.optim.Adam(policy.parameters(), lr=cfg.learning_rate)
+
+    reward_manager = build_reward_manager()
+    rollout_engine = SynchronousRolloutEngine(
+        env=env,
+        policy=policy,
+        reward_manager=reward_manager,
+        horizon=cfg.horizon,
+    )
+    buffer = TrajectoryBuffer(capacity=4)
+    trainer = PPOTrainer(
+        policy=policy,
+        optimizer=optimizer,
+        clip_range=cfg.clip_range,
+        value_coef=cfg.value_coef,
+        entropy_coef=cfg.entropy_coef,
+        kl_coef=cfg.kl_coef,
+        adaptive_kl=cfg.adaptive_kl,
+        kl_target=cfg.kl_target,
+        kl_adaptation_speed=cfg.kl_adaptation_speed,
+        reference_model="copy",
+    )
+    rate_tracker = RateTracker(window_seconds=30.0)
+
+    total_episodes = 0
+    for iteration in range(cfg.total_iterations):
+        trajectories = rollout_engine.generate()
+        buffer.put(trajectories)
+        batch = buffer.get()
+        metrics = trainer.step(batch)
+        completed = trajectories.completed_episodes()
+        total_episodes += completed
+        rate_tracker.update(completed)
+        eps_per_sec = rate_tracker.rate()
+
+        signal_means = {
+            name: float(values.mean())
+            for name, values in reward_manager.latest_signal_values.items()
+        }
+        logging.info(
+            (
+                "iter=%d reward=%.3f obj=%.4f kl=%.4f kl_ref=%.4f entropy=%.3f eps/s=%.2f "
+                "signals=%s"
+            ),
+            iteration,
+            metrics["reward_mean"],
+            metrics["policy_objective"],
+            metrics["kl"],
+            metrics["kl_to_ref"],
+            metrics["entropy"],
+            eps_per_sec,
+            {k: round(v, 3) for k, v in signal_means.items()},
+        )
+        if iteration % 10 == 0 and reward_manager.latest_histograms:
+            for name, hist in reward_manager.latest_histograms.items():
+                if hist is None:
+                    continue
+                counts = [round(c, 2) for c in hist["counts"]]
+                logging.info("hist_%s=%s", name, counts)
+
+    logging.info("Finished RLVR math run over %d episodes", total_episodes)
+
+
+if __name__ == "__main__":  # pragma: no cover - example script
+    main()
+

--- a/rewards/rlvr/__init__.py
+++ b/rewards/rlvr/__init__.py
@@ -1,8 +1,7 @@
-"""Reward modules."""
+"""Verifiable reward utilities."""
 
-from .fake.basic import IdentityRewardManager, NoisyRewardManager
-from .rlvr.manager import VerifiableRewardManager
-from .rlvr.signals import (
+from .manager import VerifiableRewardManager
+from .signals import (
     HFRewardModelSignal,
     HTTPRewardModelSignal,
     MathAnswerSignal,
@@ -12,8 +11,6 @@ from .rlvr.signals import (
 )
 
 __all__ = [
-    "IdentityRewardManager",
-    "NoisyRewardManager",
     "VerifiableRewardManager",
     "VerifiableSignal",
     "RegexMatchSignal",
@@ -22,3 +19,4 @@ __all__ = [
     "HFRewardModelSignal",
     "HTTPRewardModelSignal",
 ]
+

--- a/rewards/rlvr/manager.py
+++ b/rewards/rlvr/manager.py
@@ -1,0 +1,80 @@
+"""Reward manager that mixes multiple verifiable reward signals."""
+
+from __future__ import annotations
+
+from typing import Any, Mapping, Sequence
+
+import torch
+
+from core.interfaces import EnvStep
+from rewards.base import RewardManagerBase
+from rewards.rlvr.signals import VerifiableSignal
+
+
+class VerifiableRewardManager(RewardManagerBase):
+    """Combines several verifiable signals into a single reward tensor."""
+
+    def __init__(
+        self,
+        signals: Sequence[VerifiableSignal],
+        *,
+        include_environment_reward: bool = False,
+        mix: str = "sum",
+        normalize_weights: bool = False,
+    ) -> None:
+        if not signals:
+            raise ValueError("VerifiableRewardManager requires at least one signal")
+        self.signals = list(signals)
+        self.include_environment_reward = include_environment_reward
+        if mix not in {"sum", "mean"}:
+            raise ValueError("mix must be either 'sum' or 'mean'")
+        self.mix = mix
+        self.normalize_weights = normalize_weights
+        self.latest_signal_values: dict[str, torch.Tensor] = {}
+        self.latest_histograms: dict[str, dict[str, list[float]] | None] = {}
+
+    def score(self, samples: Any) -> torch.Tensor:
+        if isinstance(samples, EnvStep):
+            infos = samples.infos
+            base_reward = samples.rewards
+            device = base_reward.device
+            zeros = torch.zeros_like(base_reward, dtype=torch.float32)
+        elif isinstance(samples, Mapping):
+            infos = samples.get("infos")
+            if infos is None:
+                raise KeyError("Mapping samples must contain an 'infos' key")
+            zeros = torch.zeros(len(infos), dtype=torch.float32)
+            device = zeros.device
+            base_reward = zeros
+        else:
+            raise TypeError("VerifiableRewardManager expects an EnvStep or mapping")
+
+        if not isinstance(infos, Sequence):
+            raise TypeError("infos must be a sequence of rollout metadata")
+        total = torch.zeros(len(infos), dtype=torch.float32, device=device)
+        weight_sum = 0.0
+        self.latest_signal_values = {}
+        self.latest_histograms = {}
+
+        for signal in self.signals:
+            result = signal(infos)
+            weighted = result.weighted.to(device)
+            total = total + weighted
+            weight_sum += abs(signal.weight)
+            self.latest_signal_values[signal.name] = result.raw.detach().cpu()
+            self.latest_histograms[signal.name] = signal.latest_histogram
+
+        if self.normalize_weights and weight_sum > 0:
+            total = total / weight_sum
+
+        if self.mix == "mean" and self.signals:
+            total = total / float(len(self.signals))
+
+        if self.include_environment_reward:
+            total = total + base_reward.to(device)
+
+        return total
+
+
+__all__ = ["VerifiableRewardManager"]
+

--- a/rewards/rlvr/signals.py
+++ b/rewards/rlvr/signals.py
@@ -1,0 +1,401 @@
+"""Signal definitions for reinforcement learning from verifiable rewards."""
+
+from __future__ import annotations
+
+import abc
+import json
+import math
+import re
+from dataclasses import dataclass
+from typing import Any, Callable, Iterable, Mapping, MutableMapping, Sequence
+
+import torch
+
+
+@dataclass(slots=True)
+class SignalResult:
+    """Container holding both raw and weighted scores for a signal."""
+
+    raw: torch.Tensor
+    weighted: torch.Tensor
+
+
+class VerifiableSignal(abc.ABC):
+    """Base class for verifiable reward signals.
+
+    Subclasses implement :meth:`_batch_score` or :meth:`_score_single` to
+    transform rollout metadata (typically stored in ``EnvStep.infos``) into a
+    tensor of scalar scores. Each signal can be assigned an arbitrary weight and
+    records a histogram of the most recent batch of raw scores to make reward
+    debugging easier.
+    """
+
+    def __init__(
+        self,
+        name: str,
+        weight: float = 1.0,
+        histogram_bins: int = 20,
+    ) -> None:
+        if not name:
+            raise ValueError("Signal name must be a non-empty string")
+        self.name = name
+        self.weight = float(weight)
+        self.histogram_bins = int(histogram_bins)
+        if self.histogram_bins <= 0:
+            raise ValueError("histogram_bins must be positive")
+        self.latest_histogram: dict[str, list[float]] | None = None
+        self.latest_raw: torch.Tensor | None = None
+
+    def __call__(self, infos: Sequence[Mapping[str, Any]]) -> SignalResult:
+        if not isinstance(infos, Sequence):
+            raise TypeError("infos must be a sequence of mappings")
+        raw = self._batch_score(infos)
+        if not isinstance(raw, torch.Tensor):
+            raw = torch.as_tensor(raw, dtype=torch.float32)
+        raw = raw.to(dtype=torch.float32)
+        if raw.dim() != 1:
+            raise ValueError(
+                f"Signal '{self.name}' expected a 1D tensor of scores, got {raw.shape}"
+            )
+        self.latest_raw = raw.detach().cpu()
+        self.latest_histogram = self._compute_histogram(raw)
+        weighted = raw * self.weight
+        return SignalResult(raw=raw, weighted=weighted)
+
+    def _compute_histogram(self, values: torch.Tensor) -> dict[str, list[float]] | None:
+        if values.numel() == 0:
+            return None
+        hist = torch.histogram(values, bins=self.histogram_bins)
+        edges = hist.bin_edges.detach().cpu().tolist()
+        counts = hist.hist.detach().cpu().tolist()
+        return {"edges": edges, "counts": counts}
+
+    def _batch_score(self, infos: Sequence[Mapping[str, Any]]) -> torch.Tensor:
+        scores = [self._score_single(info) for info in infos]
+        if scores and isinstance(scores[0], torch.Tensor):
+            return torch.stack([torch.as_tensor(s, dtype=torch.float32) for s in scores])
+        return torch.as_tensor(scores, dtype=torch.float32)
+
+    def _score_single(self, info: Mapping[str, Any]) -> float | torch.Tensor:
+        """Score a single rollout info mapping.
+
+        Subclasses overriding :meth:`_batch_score` do not need to implement this
+        method. The base implementation raises ``NotImplementedError`` to catch
+        accidental fall-through during development.
+        """
+
+        raise NotImplementedError(
+            f"Signal '{self.name}' does not implement '_score_single'"
+        )
+
+
+class RegexMatchSignal(VerifiableSignal):
+    """Scores outputs that satisfy a regular expression constraint."""
+
+    def __init__(
+        self,
+        name: str,
+        pattern: str | None = None,
+        *,
+        completion_key: str = "completion",
+        pattern_key: str | None = None,
+        positive_reward: float = 1.0,
+        negative_reward: float = 0.0,
+        flags: int = 0,
+        weight: float = 1.0,
+        histogram_bins: int = 20,
+    ) -> None:
+        super().__init__(name=name, weight=weight, histogram_bins=histogram_bins)
+        if pattern is None and pattern_key is None:
+            raise ValueError("RegexMatchSignal requires either pattern or pattern_key")
+        self._compiled = re.compile(pattern, flags) if pattern is not None else None
+        self.pattern_key = pattern_key
+        self.completion_key = completion_key
+        self.positive_reward = float(positive_reward)
+        self.negative_reward = float(negative_reward)
+
+    def _resolve_pattern(self, info: Mapping[str, Any]) -> re.Pattern[str]:
+        if self._compiled is not None:
+            return self._compiled
+        if self.pattern_key is None:
+            raise RuntimeError("No pattern configured for RegexMatchSignal")
+        raw = info.get(self.pattern_key)
+        if raw is None:
+            raise KeyError(f"Info dictionary missing pattern key '{self.pattern_key}'")
+        if not isinstance(raw, str):
+            raise TypeError(
+                f"Pattern extracted from key '{self.pattern_key}' must be a string, got {type(raw)!r}"
+            )
+        return re.compile(raw)
+
+    def _score_single(self, info: Mapping[str, Any]) -> float:
+        text = str(info.get(self.completion_key, ""))
+        pattern = self._resolve_pattern(info)
+        return self.positive_reward if pattern.search(text) else self.negative_reward
+
+
+class MathAnswerSignal(VerifiableSignal):
+    """Checks whether the extracted final answer matches the reference solution."""
+
+    def __init__(
+        self,
+        name: str,
+        *,
+        answer_key: str = "answer",
+        completion_key: str = "completion",
+        extractor: Callable[[str], float | None] | None = None,
+        correct_reward: float = 1.0,
+        incorrect_reward: float = 0.0,
+        tolerance: float = 1e-3,
+        weight: float = 1.0,
+        histogram_bins: int = 20,
+    ) -> None:
+        super().__init__(name=name, weight=weight, histogram_bins=histogram_bins)
+        self.answer_key = answer_key
+        self.completion_key = completion_key
+        self.extractor = extractor or self._default_extractor
+        self.correct_reward = float(correct_reward)
+        self.incorrect_reward = float(incorrect_reward)
+        self.tolerance = float(tolerance)
+
+    @staticmethod
+    def _default_extractor(text: str) -> float | None:
+        """Heuristic extractor that returns the final numeric answer from text."""
+
+        if not text:
+            return None
+        # Common GSM8K/MATH formats include "#### 42" or "\boxed{42}".
+        candidates = re.findall(r"-?\d+(?:\.\d+)?", text)
+        if not candidates:
+            return None
+        try:
+            return float(candidates[-1])
+        except ValueError:
+            return None
+
+    def _score_single(self, info: Mapping[str, Any]) -> float:
+        completion = str(info.get(self.completion_key, ""))
+        expected = info.get(self.answer_key)
+        if expected is None:
+            raise KeyError(f"Info dictionary missing answer key '{self.answer_key}'")
+        predicted = self.extractor(completion)
+        if predicted is None:
+            return self.incorrect_reward
+        try:
+            expected_value = float(expected)
+        except (TypeError, ValueError):
+            expected_value = None
+        if expected_value is None:
+            return self.correct_reward if str(expected).strip() == str(predicted).strip() else self.incorrect_reward
+        return (
+            self.correct_reward
+            if math.isclose(predicted, expected_value, rel_tol=0.0, abs_tol=self.tolerance)
+            else self.incorrect_reward
+        )
+
+
+class UnitTestSignal(VerifiableSignal):
+    """Executes unit tests defined in rollout metadata."""
+
+    def __init__(
+        self,
+        name: str,
+        *,
+        completion_key: str = "completion",
+        tests_key: str = "tests",
+        entry_point_key: str = "entry_point",
+        success_reward: float = 1.0,
+        failure_reward: float = 0.0,
+        weight: float = 1.0,
+        histogram_bins: int = 20,
+    ) -> None:
+        super().__init__(name=name, weight=weight, histogram_bins=histogram_bins)
+        self.completion_key = completion_key
+        self.tests_key = tests_key
+        self.entry_point_key = entry_point_key
+        self.success_reward = float(success_reward)
+        self.failure_reward = float(failure_reward)
+
+    def _score_single(self, info: Mapping[str, Any]) -> float:
+        source = info.get(self.completion_key, "")
+        tests = info.get(self.tests_key)
+        entry_point = info.get(self.entry_point_key, "solution")
+        if not isinstance(source, str):
+            raise TypeError(
+                f"UnitTestSignal expects completion text to be a string, got {type(source)!r}"
+            )
+        if not isinstance(entry_point, str):
+            raise TypeError(
+                f"Entry point must be a string, got {type(entry_point)!r}"
+            )
+        if not tests:
+            return self.failure_reward
+        if not isinstance(tests, Sequence):
+            raise TypeError("tests metadata must be a sequence of dictionaries")
+        namespace: MutableMapping[str, Any] = {}
+        try:
+            exec(source, namespace)
+        except Exception:
+            return self.failure_reward
+        fn = namespace.get(entry_point)
+        if not callable(fn):
+            return self.failure_reward
+        total = 0
+        passed = 0
+        for case in tests:
+            if not isinstance(case, Mapping):
+                raise TypeError("Test cases must be mappings")
+            args = list(case.get("args", ()))
+            kwargs = dict(case.get("kwargs", {}))
+            expected = case.get("expected")
+            total += 1
+            try:
+                result = fn(*args, **kwargs)
+            except Exception:
+                continue
+            if result == expected:
+                passed += 1
+        if total == 0:
+            return self.failure_reward
+        ratio = passed / total
+        return self.failure_reward + ratio * (self.success_reward - self.failure_reward)
+
+
+class HFRewardModelSignal(VerifiableSignal):
+    """Scores outputs using a Hugging Face reward model."""
+
+    def __init__(
+        self,
+        name: str,
+        *,
+        model_name: str,
+        completion_key: str = "completion",
+        prompt_key: str | None = "prompt",
+        device: torch.device | None = None,
+        apply_sigmoid: bool = True,
+        weight: float = 1.0,
+        histogram_bins: int = 20,
+    ) -> None:
+        super().__init__(name=name, weight=weight, histogram_bins=histogram_bins)
+        self.model_name = model_name
+        self.completion_key = completion_key
+        self.prompt_key = prompt_key
+        self.device = device or torch.device("cpu")
+        self.apply_sigmoid = apply_sigmoid
+        self._model = None
+        self._tokenizer = None
+
+    def _ensure_model(self) -> None:
+        if self._model is not None and self._tokenizer is not None:
+            return
+        try:
+            from transformers import AutoModelForSequenceClassification, AutoTokenizer
+        except ImportError as exc:  # pragma: no cover - optional dependency
+            raise RuntimeError(
+                "transformers is required for HFRewardModelSignal"
+            ) from exc
+        self._tokenizer = AutoTokenizer.from_pretrained(self.model_name)
+        self._model = AutoModelForSequenceClassification.from_pretrained(self.model_name)
+        self._model.to(self.device)
+        self._model.eval()
+
+    def _batch_score(self, infos: Sequence[Mapping[str, Any]]) -> torch.Tensor:
+        self._ensure_model()
+        assert self._tokenizer is not None  # for type checker
+        assert self._model is not None
+        texts = [str(info.get(self.completion_key, "")) for info in infos]
+        if self.prompt_key is not None:
+            prompts = [str(info.get(self.prompt_key, "")) for info in infos]
+            encoded = self._tokenizer(
+                prompts,
+                texts,
+                return_tensors="pt",
+                padding=True,
+                truncation=True,
+            )
+        else:
+            encoded = self._tokenizer(
+                texts,
+                return_tensors="pt",
+                padding=True,
+                truncation=True,
+            )
+        encoded = {k: v.to(self.device) for k, v in encoded.items()}
+        with torch.no_grad():  # pragma: no cover - depends on external model
+            outputs = self._model(**encoded)
+        logits = outputs.logits
+        if logits.dim() == 1:
+            scores = logits
+        else:
+            # Use the first column when multiple logits are provided.
+            scores = logits[:, 0]
+        if self.apply_sigmoid:
+            scores = torch.sigmoid(scores)
+        return scores.detach().cpu()
+
+
+class HTTPRewardModelSignal(VerifiableSignal):
+    """Scores outputs by querying an HTTP microservice."""
+
+    def __init__(
+        self,
+        name: str,
+        *,
+        endpoint: str,
+        completion_key: str = "completion",
+        prompt_key: str | None = "prompt",
+        timeout: float = 5.0,
+        client: Callable[[Mapping[str, Any]], Sequence[float]] | None = None,
+        weight: float = 1.0,
+        histogram_bins: int = 20,
+    ) -> None:
+        super().__init__(name=name, weight=weight, histogram_bins=histogram_bins)
+        self.endpoint = endpoint
+        self.completion_key = completion_key
+        self.prompt_key = prompt_key
+        self.timeout = timeout
+        self.client = client
+
+    def _call_remote(self, payload: Mapping[str, Any]) -> Sequence[float]:
+        if self.client is not None:
+            return self.client(payload)
+        import urllib.request  # pragma: no cover - network path
+
+        data = json.dumps(payload).encode("utf-8")
+        request = urllib.request.Request(
+            self.endpoint,
+            data=data,
+            headers={"Content-Type": "application/json"},
+        )
+        with urllib.request.urlopen(request, timeout=self.timeout) as response:
+            raw = response.read().decode("utf-8")
+        parsed = json.loads(raw)
+        scores = parsed.get("scores")
+        if not isinstance(scores, Sequence):
+            raise ValueError("HTTP reward model response missing 'scores' list")
+        return [float(x) for x in scores]
+
+    def _batch_score(self, infos: Sequence[Mapping[str, Any]]) -> torch.Tensor:
+        payload: dict[str, Any] = {
+            "completions": [str(info.get(self.completion_key, "")) for info in infos]
+        }
+        if self.prompt_key is not None:
+            payload["prompts"] = [str(info.get(self.prompt_key, "")) for info in infos]
+        scores = self._call_remote(payload)
+        if len(scores) != len(infos):
+            raise ValueError(
+                f"HTTP reward model returned {len(scores)} scores for {len(infos)} requests"
+            )
+        return torch.as_tensor(scores, dtype=torch.float32)
+
+
+__all__ = [
+    "SignalResult",
+    "VerifiableSignal",
+    "RegexMatchSignal",
+    "MathAnswerSignal",
+    "UnitTestSignal",
+    "HFRewardModelSignal",
+    "HTTPRewardModelSignal",
+]
+

--- a/tests/test_rlvr.py
+++ b/tests/test_rlvr.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from core.interfaces import EnvStep
+from rewards.rlvr.manager import VerifiableRewardManager
+from rewards.rlvr.signals import (
+    HTTPRewardModelSignal,
+    MathAnswerSignal,
+    RegexMatchSignal,
+    UnitTestSignal,
+)
+
+
+def make_env_step(infos: list[dict[str, object]]) -> EnvStep:
+    batch = len(infos)
+    observations = torch.zeros(batch, 3)
+    rewards = torch.zeros(batch)
+    dones = torch.zeros(batch)
+    return EnvStep(observations=observations, rewards=rewards, dones=dones, infos=infos)
+
+
+def test_math_answer_signal() -> None:
+    signal = MathAnswerSignal(name="math", answer_key="answer", completion_key="completion")
+    infos = [
+        {"completion": "We compute carefully. Answer: 42", "answer": 42},
+        {"completion": "Final response is 13", "answer": 10},
+    ]
+    result = signal(infos)
+    assert pytest.approx(result.raw.tolist()) == [1.0, 0.0]
+
+
+def test_regex_signal_pattern_key() -> None:
+    signal = RegexMatchSignal(
+        name="format",
+        pattern_key="pattern",
+        completion_key="completion",
+        positive_reward=0.2,
+        negative_reward=-0.1,
+    )
+    infos = [
+        {"completion": "Answer: 7", "pattern": r"Answer:\s*\d+"},
+        {"completion": "No prefix", "pattern": r"Answer:\s*\d+"},
+    ]
+    result = signal(infos)
+    assert pytest.approx(result.raw.tolist()) == [0.2, -0.1]
+
+
+def test_unit_test_signal_partial_pass() -> None:
+    signal = UnitTestSignal(
+        name="unit",
+        completion_key="completion",
+        tests_key="tests",
+        entry_point_key="entry",
+        success_reward=1.0,
+        failure_reward=-1.0,
+    )
+    good_impl = "def solve(x):\n    return x * x\n"
+    bad_impl = "def solve(x):\n    return x + 1\n"
+    infos = [
+        {
+            "completion": good_impl,
+            "tests": [{"args": [2], "expected": 4}, {"args": [3], "expected": 9}],
+            "entry": "solve",
+        },
+        {
+            "completion": bad_impl,
+            "tests": [{"args": [2], "expected": 4}, {"args": [3], "expected": 9}],
+            "entry": "solve",
+        },
+    ]
+    result = signal(infos)
+    # Good implementation gets the full success reward, the bad one fails both tests.
+    assert pytest.approx(result.raw.tolist()) == [1.0, -1.0]
+
+
+def test_http_reward_signal_stub() -> None:
+    def client(payload: dict[str, object]) -> list[float]:
+        return [float(len(text)) for text in payload["completions"]]
+
+    signal = HTTPRewardModelSignal(
+        name="http",
+        endpoint="http://unused",
+        completion_key="completion",
+        prompt_key="prompt",
+        client=client,
+    )
+    infos = [
+        {"completion": "abc", "prompt": "p"},
+        {"completion": "abcd", "prompt": "q"},
+    ]
+    result = signal(infos)
+    assert pytest.approx(result.raw.tolist()) == [3.0, 4.0]
+
+
+def test_reward_manager_mixes_signals() -> None:
+    math_signal = MathAnswerSignal(name="math", answer_key="answer", completion_key="completion")
+    regex_signal = RegexMatchSignal(
+        name="regex",
+        pattern_key="pattern",
+        completion_key="completion",
+        positive_reward=0.5,
+        negative_reward=0.0,
+        weight=0.2,
+    )
+    manager = VerifiableRewardManager(
+        signals=[math_signal, regex_signal],
+        normalize_weights=True,
+    )
+    infos = [
+        {"completion": "Answer: 10", "answer": 10, "pattern": r"Answer:\s*\d+"},
+        {"completion": "Final=5", "answer": 7, "pattern": r"Answer:\s*\d+"},
+    ]
+    step = make_env_step(infos)
+    rewards = manager.score(step)
+    assert rewards.shape == (2,)
+    assert rewards[0] > rewards[1]
+    assert "math" in manager.latest_histograms
+


### PR DESCRIPTION
## Summary
- add a verifiable reward manager that mixes weighted signal scores and tracks per-signal histograms
- implement reusable verifiable signals for math answers, regex checks, unit tests, Hugging Face models, and HTTP microservices
- provide a verifiable prompt environment plus runnable RLVR math and code examples with accompanying tests

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68cef56454c88332887aec5049db56d3