### PR TITLE
Add vision-language prompt environment and VQA PPO example

### DIFF
--- a/envs/__init__.py
+++ b/envs/__init__.py
@@ -2,9 +2,25 @@
 
 from .prompt.single_turn import PreferenceDataset, SingleTurnPreferenceEnvironment
 from .prompt.toy import ToyPromptEnvironment
+from .vision_prompt_env import (
+    SimpleTextVectoriser,
+    VisionPromptDataset,
+    VisionPromptEmbeddingCollator,
+    VisionPromptEnvironment,
+    VisionPromptSample,
+    VisionPromptTokenCollator,
+    default_image_transform,
+)
 
 __all__ = [
     "PreferenceDataset",
     "SingleTurnPreferenceEnvironment",
     "ToyPromptEnvironment",
+    "VisionPromptSample",
+    "VisionPromptDataset",
+    "VisionPromptEnvironment",
+    "VisionPromptEmbeddingCollator",
+    "VisionPromptTokenCollator",
+    "SimpleTextVectoriser",
+    "default_image_transform",
 ]

--- a/envs/vision_prompt_env.py
+++ b/envs/vision_prompt_env.py
@@ -1,0 +1,370 @@
+"""Vision-language prompt environment with multi-modal preprocessing helpers."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Callable, Iterable, Mapping, MutableMapping, Sequence
+
+import numpy as np
+import torch
+import torch.nn.functional as F
+
+from core.interfaces import EnvStep
+from envs.base import BatchedEnvironment
+
+
+# ---------------------------------------------------------------------------
+# Dataset containers
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class VisionPromptSample:
+    """Single prompt consisting of an image, a question, and answer choices."""
+
+    image: np.ndarray | torch.Tensor
+    question: str
+    choices: Sequence[str]
+    answer_index: int
+    metadata: Mapping[str, object] | None = None
+
+    def __post_init__(self) -> None:
+        if not self.choices:
+            raise ValueError("VisionPromptSample requires at least one answer choice")
+        if not 0 <= self.answer_index < len(self.choices):
+            raise ValueError(
+                "answer_index must reference one of the provided answer choices"
+            )
+
+
+class VisionPromptDataset(Sequence[VisionPromptSample]):
+    """In-memory dataset of vision-language prompts."""
+
+    def __init__(self, samples: Sequence[VisionPromptSample]) -> None:
+        if not samples:
+            raise ValueError("VisionPromptDataset requires at least one sample")
+        choice_sizes = {len(sample.choices) for sample in samples}
+        if len(choice_sizes) != 1:
+            raise ValueError("All samples must expose the same number of answer choices")
+        self._samples = list(samples)
+
+    def __len__(self) -> int:  # pragma: no cover - trivial
+        return len(self._samples)
+
+    def __getitem__(self, index: int) -> VisionPromptSample:
+        return self._samples[index]
+
+    @property
+    def action_dim(self) -> int:
+        """Number of discrete answers available for each sample."""
+
+        return len(self._samples[0].choices)
+
+    def iter_texts(self) -> Iterable[str]:
+        """Yield every textual fragment for vocabulary building utilities."""
+
+        for sample in self._samples:
+            yield sample.question
+            for choice in sample.choices:
+                yield choice
+
+
+# ---------------------------------------------------------------------------
+# Image preprocessing helpers
+# ---------------------------------------------------------------------------
+def _to_chw_tensor(data: np.ndarray | torch.Tensor) -> torch.Tensor:
+    """Convert supported inputs into a 3xHxW floating point tensor."""
+
+    if isinstance(data, torch.Tensor):
+        tensor = data.detach().clone().float()
+    else:
+        tensor = torch.from_numpy(np.asarray(data)).float()
+
+    if tensor.ndim == 2:
+        tensor = tensor.unsqueeze(0)
+    elif tensor.ndim == 3 and tensor.shape[0] in {1, 3}:
+        pass
+    elif tensor.ndim == 3 and tensor.shape[-1] in {1, 3}:
+        tensor = tensor.permute(2, 0, 1)
+    else:  # pragma: no cover - defensive branch
+        raise ValueError("Unsupported image tensor shape")
+
+    if tensor.shape[0] == 1:
+        tensor = tensor.expand(3, *tensor.shape[1:])
+    if tensor.max() > 1.0:
+        tensor = tensor / 255.0
+    return tensor.clamp(0.0, 1.0)
+
+
+def default_image_transform(image: np.ndarray | torch.Tensor, size: int = 64) -> torch.Tensor:
+    """Resize and normalise the image to a square float tensor."""
+
+    tensor = _to_chw_tensor(image)
+    if tensor.shape[1:] != (size, size):
+        tensor = F.interpolate(
+            tensor.unsqueeze(0),
+            size=(size, size),
+            mode="bilinear",
+            align_corners=False,
+        ).squeeze(0)
+    return tensor
+
+
+# ---------------------------------------------------------------------------
+# Lightweight text vectoriser for embedding-style collators
+# ---------------------------------------------------------------------------
+
+
+def _tokenise(text: str) -> list[str]:
+    return re.findall(r"\b\w+\b", text.lower())
+
+
+class SimpleTextVectoriser:
+    """Bag-of-words style vectoriser for toy embedding models."""
+
+    def __init__(self, vocabulary: Sequence[str]) -> None:
+        if not vocabulary:
+            raise ValueError("Vocabulary must contain at least one token")
+        self._token_to_index = {token: idx for idx, token in enumerate(vocabulary)}
+
+    @classmethod
+    def from_dataset(cls, dataset: VisionPromptDataset) -> "SimpleTextVectoriser":
+        tokens: set[str] = set()
+        for text in dataset.iter_texts():
+            tokens.update(_tokenise(text))
+        if not tokens:
+            tokens = {"placeholder"}
+        return cls(sorted(tokens))
+
+    @property
+    def dimension(self) -> int:
+        return len(self._token_to_index)
+
+    def encode(self, text: str) -> torch.Tensor:
+        counts = torch.zeros(self.dimension, dtype=torch.float32)
+        for token in _tokenise(text):
+            idx = self._token_to_index.get(token)
+            if idx is not None:
+                counts[idx] += 1.0
+        norm = torch.linalg.norm(counts)
+        if norm > 0:
+            counts /= norm
+        return counts
+
+
+# ---------------------------------------------------------------------------
+# Multi-modal collators
+# ---------------------------------------------------------------------------
+
+
+class VisionPromptEmbeddingCollator:
+    """Produce fused text and image embeddings for tiny VLM backbones."""
+
+    def __init__(
+        self,
+        dataset: VisionPromptDataset,
+        *,
+        text_vectoriser: SimpleTextVectoriser | None = None,
+        image_transform: Callable[[np.ndarray | torch.Tensor], torch.Tensor] | None = None,
+    ) -> None:
+        self.dataset = dataset
+        self.text_vectoriser = text_vectoriser or SimpleTextVectoriser.from_dataset(dataset)
+        self.image_transform = image_transform or (lambda image: default_image_transform(image))
+
+    def __call__(self, indices: Sequence[int]) -> Mapping[str, torch.Tensor]:
+        text_features = []
+        image_features = []
+        labels = []
+        for index in indices:
+            sample = self.dataset[index]
+            combined_text = " ".join([sample.question, *sample.choices])
+            text_features.append(self.text_vectoriser.encode(combined_text))
+            image_tensor = self.image_transform(sample.image)
+            image_features.append(image_tensor.reshape(-1))
+            labels.append(sample.answer_index)
+        text_tensor = torch.stack(text_features, dim=0)
+        image_tensor = torch.stack(image_features, dim=0)
+        label_tensor = torch.tensor(labels, dtype=torch.long)
+        return {
+            "text_embeddings": text_tensor,
+            "image_embeddings": image_tensor,
+            "labels": label_tensor,
+        }
+
+
+class VisionPromptTokenCollator:
+    """Collate prompts for models that rely on special image tokens."""
+
+    def __init__(
+        self,
+        dataset: VisionPromptDataset,
+        tokenizer,
+        *,
+        image_transform: Callable[[np.ndarray | torch.Tensor], torch.Tensor] | None = None,
+        image_token: str = "<image>",
+        chat_formatter: Callable[[VisionPromptSample, str], str] | None = None,
+    ) -> None:
+        try:
+            vocab_size_before = len(tokenizer)
+        except TypeError:  # pragma: no cover - some tokenisers do not define __len__
+            vocab_size_before = None
+        added = 0
+        if hasattr(tokenizer, "add_special_tokens"):
+            added = tokenizer.add_special_tokens(
+                {"additional_special_tokens": [image_token]}
+            )
+        if added == 0 and vocab_size_before is not None and image_token not in tokenizer.get_vocab():
+            raise ValueError(
+                "Tokenizer must recognise the image token. Ensure it is added as an additional special token."
+            )
+        token_id = tokenizer.convert_tokens_to_ids(image_token)
+        if token_id is None or token_id < 0:
+            raise ValueError("Tokenizer failed to provide an id for the image token")
+
+        self.dataset = dataset
+        self.tokenizer = tokenizer
+        self.image_transform = image_transform or (lambda image: default_image_transform(image))
+        self.image_token = image_token
+        self.image_token_id = int(token_id)
+        self.chat_formatter = chat_formatter
+
+    def _format_prompt(self, sample: VisionPromptSample) -> str:
+        if self.chat_formatter is not None:
+            return self.chat_formatter(sample, self.image_token)
+        options = []
+        for idx, choice in enumerate(sample.choices):
+            label = chr(ord("A") + idx)
+            options.append(f"({label}) {choice}")
+        option_block = "\n".join(options)
+        return (
+            f"{self.image_token}\n"
+            f"Question: {sample.question}\n"
+            f"Choices:\n{option_block}\n"
+            "Answer:"
+        )
+
+    def __call__(self, indices: Sequence[int]) -> Mapping[str, torch.Tensor]:
+        prompts = []
+        images = []
+        labels = []
+        for index in indices:
+            sample = self.dataset[index]
+            prompts.append(self._format_prompt(sample))
+            images.append(self.image_transform(sample.image))
+            labels.append(sample.answer_index)
+        encoded = self.tokenizer(
+            prompts,
+            padding=True,
+            truncation=True,
+            return_tensors="pt",
+        )
+        pixel_values = torch.stack(images, dim=0)
+        label_tensor = torch.tensor(labels, dtype=torch.long)
+        return {
+            "input_ids": encoded["input_ids"],
+            "attention_mask": encoded["attention_mask"],
+            "pixel_values": pixel_values,
+            "labels": label_tensor,
+        }
+
+
+# ---------------------------------------------------------------------------
+# Environment definition
+# ---------------------------------------------------------------------------
+
+
+class VisionPromptEnvironment(BatchedEnvironment):
+    """Environment that surfaces multimodal prompts for VQA-style tasks."""
+
+    def __init__(
+        self,
+        dataset: VisionPromptDataset,
+        batch_size: int,
+        *,
+        device: torch.device | None = None,
+    ) -> None:
+        super().__init__(batch_size=batch_size, device=device)
+        self.dataset = dataset
+        self._answers = torch.tensor(
+            [sample.answer_index for sample in dataset],
+            dtype=torch.long,
+            device=self.device,
+        )
+        self.current_indices = torch.zeros(batch_size, dtype=torch.long, device=self.device)
+        self._sample_indices()
+
+    @property
+    def num_prompts(self) -> int:
+        return len(self.dataset)
+
+    @property
+    def action_dim(self) -> int:
+        return self.dataset.action_dim
+
+    def reset(self, batch_size: int | None = None) -> EnvStep:
+        if batch_size is not None and batch_size != self.batch_size:
+            raise ValueError("VisionPromptEnvironment has fixed batch size")
+        self._sample_indices()
+        observations = self.current_indices.clone().unsqueeze(-1)
+        zeros = torch.zeros(self.batch_size, device=self.device)
+        infos: Sequence[MutableMapping[str, object]] = tuple(
+            self._make_info(int(idx), None, None) for idx in self.current_indices
+        )
+        return EnvStep(observations=observations, rewards=zeros, dones=zeros, infos=infos)
+
+    def step(self, actions: torch.Tensor) -> EnvStep:
+        actions = actions.long().view(-1)
+        if actions.shape[0] != self.batch_size:
+            raise ValueError("Action batch size mismatch in VisionPromptEnvironment")
+        prompt_indices = self.current_indices
+        if torch.any(actions < 0) or torch.any(actions >= self.action_dim):
+            raise ValueError("Action index out of bounds for VisionPromptEnvironment")
+        correct_answers = self._answers[prompt_indices]
+        rewards = (actions == correct_answers).float()
+        dones = torch.ones(self.batch_size, device=self.device)
+        infos: Sequence[MutableMapping[str, object]] = tuple(
+            self._make_info(int(p.item()), int(a.item()), bool(r.item()))
+            for p, a, r in zip(prompt_indices, actions, rewards)
+        )
+        self._sample_indices()
+        next_obs = self.current_indices.clone().unsqueeze(-1)
+        return EnvStep(observations=next_obs, rewards=rewards, dones=dones, infos=infos)
+
+    def _sample_indices(self) -> None:
+        self.current_indices = torch.randint(
+            low=0,
+            high=self.num_prompts,
+            size=(self.batch_size,),
+            device=self.device,
+        )
+
+    def _make_info(
+        self, prompt_index: int, action: int | None, correct: bool | None
+    ) -> MutableMapping[str, object]:
+        sample = self.dataset[prompt_index]
+        info: MutableMapping[str, object] = {
+            "prompt_index": prompt_index,
+            "question": sample.question,
+            "choices": tuple(sample.choices),
+            "answer_index": sample.answer_index,
+        }
+        if action is not None:
+            info["action"] = action
+        if correct is not None:
+            info["correct"] = correct
+        if sample.metadata:
+            info.update(dict(sample.metadata))
+        return info
+
+
+__all__ = [
+    "VisionPromptSample",
+    "VisionPromptDataset",
+    "VisionPromptEnvironment",
+    "VisionPromptEmbeddingCollator",
+    "VisionPromptTokenCollator",
+    "SimpleTextVectoriser",
+    "default_image_transform",
+]
+

--- a/examples/ppo_vlm_vqa.py
+++ b/examples/ppo_vlm_vqa.py
@@ -1,0 +1,223 @@
+"""Train a tiny vision-language agent on a toy multiple-choice VQA task."""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Sequence
+
+import numpy as np
+import torch
+
+from algos.ppo.trainer import PPOTrainer
+from core.buffers.memory import TrajectoryBuffer
+from core.utils.timing import RateTracker
+from engines.sync.sync_engine import SynchronousRolloutEngine
+from envs.vision_prompt_env import (
+    VisionPromptDataset,
+    VisionPromptEnvironment,
+    VisionPromptSample,
+    VisionPromptTokenCollator,
+)
+from examples.vlm_wrappers import TokenFusionPolicy
+from rewards.fake.basic import IdentityRewardManager
+
+try:  # pragma: no cover - optional dependency for lightweight testing
+    from transformers import AutoTokenizer
+except Exception:  # pragma: no cover - transformers is optional
+    AutoTokenizer = None
+
+
+class SimpleTokenizer:
+    """Fallback whitespace tokenizer mirroring a tiny subset of HF tokenisers."""
+
+    def __init__(self) -> None:
+        self.token_to_id: dict[str, int] = {"<pad>": 0, "<unk>": 1}
+        self.pad_token = "<pad>"
+        self.unk_token = "<unk>"
+
+    def __len__(self) -> int:  # pragma: no cover - trivial
+        return len(self.token_to_id)
+
+    @property
+    def vocab_size(self) -> int:
+        return len(self.token_to_id)
+
+    def get_vocab(self) -> dict[str, int]:  # pragma: no cover - trivial
+        return dict(self.token_to_id)
+
+    def add_special_tokens(self, mapping: dict[str, Sequence[str]]) -> int:
+        tokens = mapping.get("additional_special_tokens", [])
+        added = 0
+        for token in tokens:
+            added += self._add_token(token)
+        return added
+
+    def add_tokens(self, tokens: Sequence[str]) -> int:  # pragma: no cover - helper
+        added = 0
+        for token in tokens:
+            added += self._add_token(token)
+        return added
+
+    def convert_tokens_to_ids(self, token: str) -> int:
+        return self.token_to_id.get(token, self.token_to_id[self.unk_token])
+
+    def encode(self, text: str) -> list[int]:
+        tokens = text.strip().split()
+        ids: list[int] = []
+        for token in tokens:
+            ids.append(self.convert_tokens_to_ids(token))
+        return ids if ids else [self.token_to_id[self.unk_token]]
+
+    def encode_with_new_tokens(self, text: str) -> list[int]:
+        tokens = text.strip().split()
+        ids: list[int] = []
+        for token in tokens:
+            self._add_token(token)
+            ids.append(self.token_to_id[token])
+        return ids if ids else [self.token_to_id[self.unk_token]]
+
+    def __call__(self, texts, padding=True, truncation=True, return_tensors="pt"):
+        del truncation  # Unused in the simple fallback implementation.
+        sequences = [self.encode(text) for text in texts]
+        max_len = max(len(seq) for seq in sequences) if sequences else 0
+        pad_id = self.convert_tokens_to_ids(self.pad_token)
+        input_ids = torch.full((len(sequences), max_len), pad_id, dtype=torch.long)
+        attention_mask = torch.zeros((len(sequences), max_len), dtype=torch.long)
+        for row, seq in enumerate(sequences):
+            input_ids[row, : len(seq)] = torch.tensor(seq, dtype=torch.long)
+            attention_mask[row, : len(seq)] = 1
+        if return_tensors != "pt":  # pragma: no cover - defensive
+            raise ValueError("SimpleTokenizer only supports return_tensors='pt'")
+        return {"input_ids": input_ids, "attention_mask": attention_mask}
+
+    def _add_token(self, token: str) -> int:
+        if token not in self.token_to_id:
+            self.token_to_id[token] = len(self.token_to_id)
+            return 1
+        return 0
+
+
+logging.basicConfig(level=logging.INFO, format="[%(levelname)s] %(message)s")
+
+
+@dataclass
+class ExperimentConfig:
+    batch_size: int = 4
+    horizon: int = 1
+    total_iterations: int = 50
+    learning_rate: float = 3e-4
+    embed_dim: int = 96
+    hidden_size: int = 128
+    image_size: int = 48
+
+
+def _make_coloured_square(colour: tuple[int, int, int], size: int) -> np.ndarray:
+    array = np.zeros((size, size, 3), dtype=np.float32)
+    array[...] = np.array(colour, dtype=np.float32)
+    return array
+
+
+def build_dataset(image_size: int) -> VisionPromptDataset:
+    colours: Sequence[tuple[str, tuple[int, int, int]]] = (
+        ("red", (220, 20, 60)),
+        ("green", (50, 205, 50)),
+        ("blue", (65, 105, 225)),
+        ("yellow", (255, 215, 0)),
+    )
+    choices: Sequence[str] = tuple(name for name, _ in colours)
+    samples: list[VisionPromptSample] = []
+    for answer_index, (name, rgb) in enumerate(colours):
+        image = _make_coloured_square(rgb, image_size)
+        sample = VisionPromptSample(
+            image=image,
+            question="What colour is the square?",
+            choices=choices,
+            answer_index=answer_index,
+            metadata={"colour": name},
+        )
+        samples.append(sample)
+    return VisionPromptDataset(samples)
+
+
+def main(cfg: ExperimentConfig | None = None) -> None:
+    cfg = cfg or ExperimentConfig()
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    torch.manual_seed(1234)
+    if torch.cuda.is_available():
+        torch.cuda.manual_seed_all(1234)
+
+    dataset = build_dataset(cfg.image_size)
+    if AutoTokenizer is not None:
+        tokenizer = AutoTokenizer.from_pretrained("hf-internal-testing/tiny-random-gpt2")
+        tokenizer.add_special_tokens({"additional_special_tokens": ["<image>"]})
+    else:
+        tokenizer = SimpleTokenizer()
+        for sample in dataset:
+            tokenizer.encode_with_new_tokens(sample.question)
+            for choice in sample.choices:
+                tokenizer.encode_with_new_tokens(choice)
+        option_tokens = [f"({chr(ord('A') + idx)})" for idx in range(dataset.action_dim)]
+        tokenizer.add_tokens(["Question:", "Choices:", "Answer:", *option_tokens])
+        tokenizer.add_special_tokens({"additional_special_tokens": ["<image>"]})
+    collator = VisionPromptTokenCollator(dataset, tokenizer, image_token="<image>")
+
+    env = VisionPromptEnvironment(dataset=dataset, batch_size=cfg.batch_size, device=device)
+    policy = TokenFusionPolicy(
+        dataset=dataset,
+        collator=collator,
+        embed_dim=cfg.embed_dim,
+        hidden_size=cfg.hidden_size,
+    ).to(device)
+    optimizer = torch.optim.Adam(policy.parameters(), lr=cfg.learning_rate)
+
+    reward_manager = IdentityRewardManager()
+    rollout_engine = SynchronousRolloutEngine(
+        env=env,
+        policy=policy,
+        reward_manager=reward_manager,
+        horizon=cfg.horizon,
+    )
+    buffer = TrajectoryBuffer(capacity=4)
+    trainer = PPOTrainer(policy=policy, optimizer=optimizer)
+    rate_tracker = RateTracker(window_seconds=30.0)
+
+    total_episodes = 0
+    for iteration in range(cfg.total_iterations):
+        trajectories = rollout_engine.generate()
+        buffer.put(trajectories)
+        batch = buffer.get()
+        metrics = trainer.step(batch)
+        completed = trajectories.completed_episodes()
+        total_episodes += completed
+        rate_tracker.update(completed)
+        eps_per_sec = rate_tracker.rate()
+        logging.info(
+            "iter=%d reward=%.3f kl=%.4f entropy=%.3f eps/s=%.2f",
+            iteration,
+            metrics["reward_mean"],
+            metrics["kl"],
+            metrics["entropy"],
+            eps_per_sec,
+        )
+
+    policy.eval()
+    with torch.no_grad():
+        indices = torch.arange(len(dataset), device=device)
+        logits = policy(indices)["logits"].softmax(dim=-1).cpu()
+    for sample, probs in zip(dataset, logits):
+        logging.info(
+            "question=%s answer=%s probs=%s",
+            sample.question,
+            sample.choices[sample.answer_index],
+            [round(p.item(), 3) for p in probs],
+        )
+
+    logging.info(
+        "Finished training %d iterations over %d episodes", cfg.total_iterations, total_episodes
+    )
+
+
+if __name__ == "__main__":  # pragma: no cover - script entry point
+    main()
+

--- a/examples/vlm_wrappers.py
+++ b/examples/vlm_wrappers.py
@@ -1,0 +1,118 @@
+"""Utility vision-language policy wrappers used in the VQA PPO example."""
+
+from __future__ import annotations
+
+import torch
+from torch import nn
+
+from envs.vision_prompt_env import (
+    VisionPromptDataset,
+    VisionPromptEmbeddingCollator,
+    VisionPromptTokenCollator,
+)
+
+
+class EmbeddingFusionPolicy(nn.Module):
+    """Tiny policy that consumes pre-computed text and image embeddings."""
+
+    def __init__(
+        self,
+        dataset: VisionPromptDataset,
+        collator: VisionPromptEmbeddingCollator,
+        *,
+        hidden_size: int = 128,
+    ) -> None:
+        super().__init__()
+        self.dataset = dataset
+        self.collator = collator
+
+        sample = collator([0])
+        text_dim = sample["text_embeddings"].shape[-1]
+        image_dim = sample["image_embeddings"].shape[-1]
+
+        self.text_proj = nn.Linear(text_dim, hidden_size)
+        self.image_proj = nn.Linear(image_dim, hidden_size)
+        self.activation = nn.Tanh()
+        self.policy_head = nn.Linear(hidden_size, dataset.action_dim)
+        self.value_head = nn.Linear(hidden_size, 1)
+
+    def forward(self, observations: torch.Tensor) -> dict[str, torch.Tensor]:
+        device = observations.device
+        indices = observations.view(-1).tolist()
+        batch = self.collator(indices)
+        text_embeddings = batch["text_embeddings"].to(device)
+        image_embeddings = batch["image_embeddings"].to(device)
+
+        hidden = self.activation(
+            self.text_proj(text_embeddings) + self.image_proj(image_embeddings)
+        )
+        logits = self.policy_head(hidden)
+        value = self.value_head(hidden)
+        return {"logits": logits, "value": value}
+
+
+class TokenFusionPolicy(nn.Module):
+    """Policy wrapper for token-based prompts with an injected image token."""
+
+    def __init__(
+        self,
+        dataset: VisionPromptDataset,
+        collator: VisionPromptTokenCollator,
+        *,
+        embed_dim: int = 128,
+        hidden_size: int = 128,
+    ) -> None:
+        super().__init__()
+        self.dataset = dataset
+        self.collator = collator
+        self.image_token_id = collator.image_token_id
+
+        vocab_size = collator.tokenizer.vocab_size
+        self.token_embeddings = nn.Embedding(vocab_size, embed_dim)
+        self.image_encoder = nn.Sequential(
+            nn.Conv2d(3, 16, kernel_size=3, stride=2, padding=1),
+            nn.GELU(),
+            nn.Conv2d(16, 32, kernel_size=3, stride=2, padding=1),
+            nn.GELU(),
+            nn.AdaptiveAvgPool2d((1, 1)),
+        )
+        self.image_projector = nn.Linear(32, embed_dim)
+        self.fusion_proj = nn.Linear(embed_dim, hidden_size)
+        self.activation = nn.Tanh()
+        self.policy_head = nn.Linear(hidden_size, dataset.action_dim)
+        self.value_head = nn.Linear(hidden_size, 1)
+
+    def _inject_image_embeddings(
+        self, input_ids: torch.Tensor, token_embeddings: torch.Tensor, image_embeds: torch.Tensor
+    ) -> torch.Tensor:
+        if token_embeddings.dim() != 3:
+            raise ValueError("token_embeddings must be [batch, seq, dim]")
+        mask = (input_ids == self.image_token_id).unsqueeze(-1)
+        if mask.any():
+            expanded = image_embeds.unsqueeze(1).expand_as(token_embeddings)
+            token_embeddings = torch.where(mask, expanded, token_embeddings)
+        return token_embeddings
+
+    def forward(self, observations: torch.Tensor) -> dict[str, torch.Tensor]:
+        device = observations.device
+        indices = observations.view(-1).tolist()
+        batch = self.collator(indices)
+        input_ids = batch["input_ids"].to(device)
+        attention_mask = batch["attention_mask"].to(device).float()
+        pixel_values = batch["pixel_values"].to(device)
+
+        token_embeds = self.token_embeddings(input_ids)
+        image_feats = self.image_encoder(pixel_values).flatten(start_dim=1)
+        image_embeds = self.image_projector(image_feats)
+        fused_tokens = self._inject_image_embeddings(input_ids, token_embeds, image_embeds)
+
+        masked = fused_tokens * attention_mask.unsqueeze(-1)
+        pooled = masked.sum(dim=1) / attention_mask.sum(dim=1, keepdim=True).clamp(min=1.0)
+        hidden = self.activation(self.fusion_proj(pooled))
+        logits = self.policy_head(hidden)
+        value = self.value_head(hidden)
+        return {"logits": logits, "value": value}
+
+
+__all__ = ["EmbeddingFusionPolicy", "TokenFusionPolicy"]
+


### PR DESCRIPTION
## Summary
- implement a vision-language prompt dataset, preprocessing utilities, and an environment for VQA-style tasks
- add lightweight vision-language policy wrappers that fuse image embeddings or replace image tokens
- provide a PPO training example for a toy VQA task with a fallback tokenizer for environments without `transformers`

## Testing
- python -m examples.ppo_vlm_vqa

------
https://chatgpt.com/codex/tasks/task_e_68d10afabd9c8332a1180b209de78ff5