### PR TITLE
Add HF export tooling, vLLM serving, and launch recipes

### DIFF
--- a/core/models/__init__.py
+++ b/core/models/__init__.py
@@ -1,0 +1,9 @@
+"""Model helpers for NovaRL."""
+
+from .hf_policy import TinyPreferencePolicyConfig, TinyPreferencePolicyModel
+
+__all__ = [
+    "TinyPreferencePolicyConfig",
+    "TinyPreferencePolicyModel",
+]
+

--- a/core/models/hf_policy.py
+++ b/core/models/hf_policy.py
@@ -1,0 +1,131 @@
+"""Hugging Face wrappers for NovaRL policies."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, Mapping, Optional
+
+import torch
+from torch import nn
+
+
+try:  # pragma: no cover - optional heavy dependency
+    from transformers import PreTrainedModel, PretrainedConfig
+    from transformers.modeling_outputs import ModelOutput
+except Exception as exc:  # pragma: no cover - transformers is optional
+    raise ImportError(
+        "The Hugging Face policy helpers require the `transformers` package to be installed."
+    ) from exc
+
+
+@dataclass
+class TinyPreferencePolicyOutput(ModelOutput):
+    """Minimal output container matching Hugging Face conventions."""
+
+    logits: torch.FloatTensor
+    values: Optional[torch.FloatTensor] = None
+
+
+class TinyPreferencePolicyConfig(PretrainedConfig):
+    """Configuration for the tiny preference policy used in tutorials."""
+
+    model_type = "novarl_tiny_policy"
+
+    def __init__(
+        self,
+        *,
+        observation_dim: int,
+        action_dim: int,
+        hidden_size: int = 64,
+        activation: str = "tanh",
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(**kwargs)
+        self.observation_dim = int(observation_dim)
+        self.action_dim = int(action_dim)
+        self.hidden_size = int(hidden_size)
+        self.activation = activation
+
+
+class TinyPreferencePolicyModel(PreTrainedModel):
+    """Hugging Face compatible module wrapping :class:`TinyPreferencePolicy`."""
+
+    config_class = TinyPreferencePolicyConfig
+
+    def __init__(self, config: TinyPreferencePolicyConfig) -> None:
+        super().__init__(config)
+        activation = config.activation.lower()
+        if activation == "tanh":
+            act_cls = nn.Tanh
+        elif activation == "relu":
+            act_cls = nn.ReLU
+        else:
+            raise ValueError(f"Unsupported activation {activation!r} for TinyPreferencePolicyModel")
+
+        self.encoder = nn.Sequential(
+            nn.Linear(config.observation_dim, config.hidden_size),
+            act_cls(),
+            nn.Linear(config.hidden_size, config.hidden_size),
+            act_cls(),
+        )
+        self.policy_head = nn.Linear(config.hidden_size, config.action_dim)
+        self.value_head = nn.Linear(config.hidden_size, 1)
+        self.post_init()
+
+    def forward(
+        self,
+        input_features: torch.Tensor,
+        *,
+        return_dict: bool = True,
+        **kwargs: Any,
+    ) -> TinyPreferencePolicyOutput | tuple[torch.FloatTensor, torch.FloatTensor]:
+        """Compute action logits and value estimates."""
+
+        del kwargs  # Unused but retained for HF API compatibility.
+        if input_features.dim() == 1:
+            input_features = input_features.unsqueeze(0)
+        hidden = self.encoder(input_features)
+        logits = self.policy_head(hidden)
+        values = self.value_head(hidden)
+
+        if not return_dict:
+            return logits, values
+        return TinyPreferencePolicyOutput(logits=logits, values=values)
+
+    def get_input_embeddings(self) -> nn.Module:
+        # The tiny policy operates directly on dense features.
+        raise NotImplementedError("TinyPreferencePolicyModel does not use token embeddings")
+
+    @classmethod
+    def from_state_dict(
+        cls,
+        state_dict: Mapping[str, torch.Tensor],
+        *,
+        observation_dim: int,
+        action_dim: int,
+        hidden_size: int,
+        activation: str = "tanh",
+    ) -> "TinyPreferencePolicyModel":
+        """Instantiate the model from a raw ``state_dict`` and shape metadata."""
+
+        config = TinyPreferencePolicyConfig(
+            observation_dim=observation_dim,
+            action_dim=action_dim,
+            hidden_size=hidden_size,
+            activation=activation,
+        )
+        model = cls(config)
+        model.load_state_dict(state_dict)
+        return model
+
+    def export_metadata(self) -> Dict[str, Any]:
+        """Return lightweight metadata bundled alongside checkpoints."""
+
+        return {
+            "model_type": self.config.model_type,
+            "observation_dim": self.config.observation_dim,
+            "action_dim": self.config.action_dim,
+            "hidden_size": self.config.hidden_size,
+            "activation": self.config.activation,
+        }
+

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,3 +1,9 @@
 # NovaRL Documentation
 
-This directory will host design documents and user guides for the NovaRL project.
+This directory hosts design documents and user guides for the NovaRL project.
+
+## Available guides
+
+- [Choosing a distributed backend](choose_your_backend.md): compare FSDP,
+  DeepSpeed ZeRO and Megatron tensor parallelism trade-offs when scaling RLHF
+  workloads.

--- a/docs/choose_your_backend.md
+++ b/docs/choose_your_backend.md
@@ -1,0 +1,60 @@
+# Choosing a Distributed Training Backend
+
+NovaRL interoperates with several distributed training strategies. This guide
+summarises when to reach for Fully Sharded Data Parallel (FSDP), DeepSpeed ZeRO
+and Megatron-LM style tensor-parallelism along with the practical trade-offs you
+should consider when scaling PPO-style reinforcement learning pipelines.
+
+## Overview
+
+| Backend            | Memory Footprint                                                                                                             | Throughput Profile                                                                                               | Ideal For                                                                                                   |
+|--------------------|------------------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------|
+| **FSDP**           | Shards parameters, gradients and optimizer state across ranks.<br>Peak memory per device is roughly ``O(total_parameters / world_size)`` when using ZeRO-3 style sharding.<br>Optional CPU offload reduces GPU pressure further at the cost of PCIe latency. | Excellent for moderate batch sizes when activation checkpointing is enabled.<br>Sequential all-gather/reduce phases introduce latency but are amortised in large batches. | Research iterations that must fit a large language model on commodity accelerators, or workloads with highly variable sequence lengths. |
+| **DeepSpeed ZeRO** | Stage 2 shards optimizer states; Stage 3 shards parameters and gradients as well.<br>Requires partitioning metadata but provides predictable memory savings.<br>CPU/NVMe offload supported. | Stage 2 performs similarly to DDP when activation checkpointing is disabled.<br>Stage 3 introduces extra communication but unlocks larger models. | Production fine-tuning with stable batch sizes where checkpoint/optimizer state partitioning is desirable. |
+| **Megatron (TP/PP)** | Tensor parallelism splits weight matrices across devices while pipeline parallelism divides layers.<br>Memory savings come from splitting activation storage; optimizer state often remains replicated.<br>Requires careful model surgery. | Highest throughput at scale for autoregressive transformers once microbatching and pipeline balancing are tuned.<br>Communication overhead is dominated by intra-layer collectives. | Massive models (70B+) where multiple GPUs must cooperate on individual forward passes.<br>Works best in homogeneous clusters with NVLink or Infiniband interconnects. |
+
+## Decision Checklist
+
+1. **Model size vs. device memory** – If the tuned policy fits on a single GPU
+   with headroom for activations, vanilla DDP may be sufficient. Otherwise
+   prefer FSDP or ZeRO-3 to shard state across devices.
+2. **Latency tolerance** – FSDP and ZeRO introduce additional collective ops.
+   Latency-sensitive applications (e.g. RL with tight inference loops) often
+   trade some memory efficiency for lower variance in step time.
+3. **Communication fabric** – Megatron assumes high-bandwidth, low-latency links
+   (NVLink, NVSwitch, Infiniband). On Ethernet clusters the synchronisation cost
+   may outweigh throughput gains.
+4. **Checkpoint portability** – ZeRO stores partitioned optimizer state while
+   FSDP exposes composite checkpoints compatible with Hugging Face out of the
+   box. Megatron checkpoints encode tensor-parallel layout and require dedicated
+   loaders during inference/export.
+
+## Recommended Configurations
+
+- **FSDP**: Use the preset exposed via `core.distributed.get_default_fsdp_preset`
+  and enable activation checkpointing for long sequences. Pair with
+  gradient-accumulation to reach target batch sizes.
+- **DeepSpeed ZeRO-3**: Start from `scripts/launch_zero3.sh`, enabling optimizer
+  and parameter offload when GPUs are memory constrained. Keep gradient
+  accumulation modest to avoid CPU/NVMe bottlenecks.
+- **Megatron-style tensor parallelism**: Combine with RL policies that reuse
+  inference-time tensor-parallel checkpoints (e.g. Llama or Falcon). Integrate
+  with vLLM for serving by exporting shard metadata alongside weights.
+
+## Throughput vs. Memory Rule of Thumb
+
+- FSDP (ZeRO-3 equivalent) yields **~4× memory savings** over DDP with a
+  **10–20% throughput hit** for medium batch sizes.
+- DeepSpeed ZeRO-2 delivers **~2× memory reduction** with **near-DDP throughput**,
+  while ZeRO-3 approaches FSDP memory efficiency at the cost of extra
+  communication.
+- Megatron tensor parallelism typically provides **linear throughput scaling up
+  to 8 GPUs** per model replica provided microbatches keep pipelines busy. Memory
+  savings stem from partitioning activations; optimizer state remains replicated
+  unless combined with ZeRO.
+
+In practice many large-scale systems blend these strategies: e.g. ZeRO-1 or
+ZeRO-2 for optimizer sharding, tensor-parallel for intra-layer scaling and FSDP
+for encoder/decoder stacks. NovaRL exposes the relevant knobs via the
+configuration presets so you can compose the right mix for your hardware.
+

--- a/examples/export_policy_to_hf.py
+++ b/examples/export_policy_to_hf.py
@@ -1,0 +1,98 @@
+"""Convert NovaRL policy checkpoints into Hugging Face format."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Mapping
+
+import torch
+
+try:  # pragma: no cover - optional dependency guard
+    from core.models.hf_policy import TinyPreferencePolicyModel
+except ImportError as exc:  # pragma: no cover - lazy error surfacing
+    _HF_IMPORT_ERROR: Exception | None = exc
+else:  # pragma: no cover - clean path when deps are present
+    _HF_IMPORT_ERROR = None
+
+
+def _load_state_dict(path: Path) -> Mapping[str, torch.Tensor]:
+    checkpoint = torch.load(path, map_location="cpu")
+    if isinstance(checkpoint, Mapping) and "model_state_dict" in checkpoint:
+        state = checkpoint["model_state_dict"]
+    elif isinstance(checkpoint, Mapping):
+        state = checkpoint
+    else:
+        raise ValueError(
+            "Unsupported checkpoint format. Expected a dict containing 'model_state_dict'."
+        )
+    return state
+
+
+def _infer_shapes(state: Mapping[str, torch.Tensor]) -> tuple[int, int, int]:
+    try:
+        encoder_weight = state["encoder.0.weight"]
+        policy_weight = state["policy_head.weight"]
+    except KeyError as exc:  # pragma: no cover - defensive branch
+        raise KeyError(
+            "Checkpoint does not match TinyPreferencePolicy layout."
+        ) from exc
+
+    observation_dim = encoder_weight.shape[1]
+    hidden_size = encoder_weight.shape[0]
+    action_dim = policy_weight.shape[0]
+    return observation_dim, action_dim, hidden_size
+
+
+def export_policy(checkpoint: Path, output_dir: Path, *, activation: str = "tanh") -> None:
+    if _HF_IMPORT_ERROR is not None:  # pragma: no cover - dependency guard
+        raise _HF_IMPORT_ERROR
+    state = _load_state_dict(checkpoint)
+    observation_dim, action_dim, hidden_size = _infer_shapes(state)
+    model = TinyPreferencePolicyModel.from_state_dict(
+        state,
+        observation_dim=observation_dim,
+        action_dim=action_dim,
+        hidden_size=hidden_size,
+        activation=activation,
+    )
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    model.save_pretrained(output_dir)
+    metadata_path = output_dir / "novarl_policy_metadata.json"
+    with metadata_path.open("w", encoding="utf-8") as handle:
+        json.dump(model.export_metadata(), handle, indent=2)
+
+
+def parse_args() -> argparse.Namespace:  # pragma: no cover - CLI plumbing
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--checkpoint",
+        type=Path,
+        required=True,
+        help="Path to the torch policy checkpoint (policy.pt).",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        required=True,
+        help="Directory where the Hugging Face artefacts will be written.",
+    )
+    parser.add_argument(
+        "--activation",
+        default="tanh",
+        choices=["tanh", "relu"],
+        help="Activation function used by the policy network.",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:  # pragma: no cover - CLI entry point
+    args = parse_args()
+    export_policy(args.checkpoint, args.output_dir, activation=args.activation)
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    main()
+

--- a/examples/recipes/README.md
+++ b/examples/recipes/README.md
@@ -1,0 +1,29 @@
+# NovaRL Launch Recipes
+
+The scripts in this folder provide ready-to-run launch commands for four common
+reinforcement learning workflows. Each recipe comes in a single-node and
+multi-node flavour. The single-node variants are designed for quick iteration on
+a single workstation or DGX, while the multi-node scripts demonstrate how to use
+`torchrun` to scale out.
+
+The scripts assume the repository root as the working directory. Set the
+`CUDA_VISIBLE_DEVICES` environment variable before invoking the single-node
+variants to choose which GPUs participate in training.
+
+| Workflow     | Single Node Script                   | Multi-Node Script                    |
+|--------------|--------------------------------------|--------------------------------------|
+| RLHF (PPO)   | `rlhf_ppo_single_node.sh`            | `rlhf_ppo_multi_node.sh`             |
+| RLVR (math)  | `rlvr_math_single_node.sh`           | `rlvr_math_multi_node.sh`            |
+| Code RL      | `code_rl_single_node.sh`             | `code_rl_multi_node.sh`              |
+| VLM (VQA)    | `vlm_vqa_single_node.sh`             | `vlm_vqa_multi_node.sh`              |
+
+To launch, grant execution permissions (once) and then run the desired script:
+
+```bash
+chmod +x examples/recipes/*.sh
+examples/recipes/rlhf_ppo_single_node.sh
+```
+
+Feel free to treat these recipes as templates—swap in your own datasets,
+hyper-parameters or parallelism knobs to match production requirements.
+

--- a/examples/recipes/code_rl_multi_node.sh
+++ b/examples/recipes/code_rl_multi_node.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+REPO_ROOT=$(cd "$SCRIPT_DIR/../.." && pwd)
+
+NPROC=${NPROC:-2}
+NNODES=${NNODES:-1}
+NODE_RANK=${NODE_RANK:-0}
+MASTER_ADDR=${MASTER_ADDR:-127.0.0.1}
+MASTER_PORT=${MASTER_PORT:-29502}
+
+cd "$REPO_ROOT"
+torchrun \
+  --nproc_per_node="$NPROC" \
+  --nnodes="$NNODES" \
+  --node_rank="$NODE_RANK" \
+  --master_addr="$MASTER_ADDR" \
+  --master_port="$MASTER_PORT" \
+  examples/recipes/multi_node_wrapper.py \
+  --target examples.rl_code "$@"
+

--- a/examples/recipes/code_rl_single_node.sh
+++ b/examples/recipes/code_rl_single_node.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+REPO_ROOT=$(cd "$SCRIPT_DIR/../.." && pwd)
+
+export CUDA_VISIBLE_DEVICES=${CUDA_VISIBLE_DEVICES:-0}
+
+cd "$REPO_ROOT"
+python -m examples.rl_code "$@"
+

--- a/examples/recipes/multi_node_wrapper.py
+++ b/examples/recipes/multi_node_wrapper.py
@@ -1,0 +1,53 @@
+"""Helper to run single-process training modules under torchrun."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import runpy
+
+import torch
+import torch.distributed as dist
+
+
+def parse_args() -> tuple[argparse.Namespace, list[str]]:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--target", required=True, help="Python module to execute on rank 0")
+    return parser.parse_known_args()
+
+
+def _maybe_init_process_group() -> None:
+    if not dist.is_available():  # pragma: no cover - defensive branch
+        return
+    if dist.is_initialized():
+        return
+    backend = "nccl" if torch.cuda.is_available() else "gloo"
+    dist.init_process_group(backend=backend)
+
+
+def main() -> None:  # pragma: no cover - CLI entry point
+    args, extra = parse_args()
+    _maybe_init_process_group()
+
+    rank = 0
+    if dist.is_available() and dist.is_initialized():
+        rank = dist.get_rank()
+    else:
+        rank = int(os.environ.get("RANK", "0"))
+
+    if rank == 0:
+        argv = [args.target, *extra]
+        import sys
+
+        sys.argv = argv
+        runpy.run_module(args.target, run_name="__main__", alter_sys=True)
+        if dist.is_available() and dist.is_initialized():
+            dist.barrier()
+    else:
+        if dist.is_available() and dist.is_initialized():
+            dist.barrier()
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    main()
+

--- a/examples/recipes/rlhf_ppo_multi_node.sh
+++ b/examples/recipes/rlhf_ppo_multi_node.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+REPO_ROOT=$(cd "$SCRIPT_DIR/../.." && pwd)
+
+NPROC=${NPROC:-2}
+NNODES=${NNODES:-1}
+NODE_RANK=${NODE_RANK:-0}
+MASTER_ADDR=${MASTER_ADDR:-127.0.0.1}
+MASTER_PORT=${MASTER_PORT:-29500}
+
+cd "$REPO_ROOT"
+torchrun \
+  --nproc_per_node="$NPROC" \
+  --nnodes="$NNODES" \
+  --node_rank="$NODE_RANK" \
+  --master_addr="$MASTER_ADDR" \
+  --master_port="$MASTER_PORT" \
+  examples/recipes/multi_node_wrapper.py \
+  --target examples.ppo_rlhf_single_turn "$@"
+

--- a/examples/recipes/rlhf_ppo_single_node.sh
+++ b/examples/recipes/rlhf_ppo_single_node.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+REPO_ROOT=$(cd "$SCRIPT_DIR/../.." && pwd)
+
+export CUDA_VISIBLE_DEVICES=${CUDA_VISIBLE_DEVICES:-0}
+
+cd "$REPO_ROOT"
+python -m examples.ppo_rlhf_single_turn "$@"
+

--- a/examples/recipes/rlvr_math_multi_node.sh
+++ b/examples/recipes/rlvr_math_multi_node.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+REPO_ROOT=$(cd "$SCRIPT_DIR/../.." && pwd)
+
+NPROC=${NPROC:-2}
+NNODES=${NNODES:-1}
+NODE_RANK=${NODE_RANK:-0}
+MASTER_ADDR=${MASTER_ADDR:-127.0.0.1}
+MASTER_PORT=${MASTER_PORT:-29501}
+
+cd "$REPO_ROOT"
+torchrun \
+  --nproc_per_node="$NPROC" \
+  --nnodes="$NNODES" \
+  --node_rank="$NODE_RANK" \
+  --master_addr="$MASTER_ADDR" \
+  --master_port="$MASTER_PORT" \
+  examples/recipes/multi_node_wrapper.py \
+  --target examples.rlvr_math "$@"
+

--- a/examples/recipes/rlvr_math_single_node.sh
+++ b/examples/recipes/rlvr_math_single_node.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+REPO_ROOT=$(cd "$SCRIPT_DIR/../.." && pwd)
+
+export CUDA_VISIBLE_DEVICES=${CUDA_VISIBLE_DEVICES:-0}
+
+cd "$REPO_ROOT"
+python -m examples.rlvr_math "$@"
+

--- a/examples/recipes/vlm_vqa_multi_node.sh
+++ b/examples/recipes/vlm_vqa_multi_node.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+REPO_ROOT=$(cd "$SCRIPT_DIR/../.." && pwd)
+
+NPROC=${NPROC:-2}
+NNODES=${NNODES:-1}
+NODE_RANK=${NODE_RANK:-0}
+MASTER_ADDR=${MASTER_ADDR:-127.0.0.1}
+MASTER_PORT=${MASTER_PORT:-29503}
+
+cd "$REPO_ROOT"
+torchrun \
+  --nproc_per_node="$NPROC" \
+  --nnodes="$NNODES" \
+  --node_rank="$NODE_RANK" \
+  --master_addr="$MASTER_ADDR" \
+  --master_port="$MASTER_PORT" \
+  examples/recipes/multi_node_wrapper.py \
+  --target examples.ppo_vlm_vqa "$@"
+

--- a/examples/recipes/vlm_vqa_single_node.sh
+++ b/examples/recipes/vlm_vqa_single_node.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+REPO_ROOT=$(cd "$SCRIPT_DIR/../.." && pwd)
+
+export CUDA_VISIBLE_DEVICES=${CUDA_VISIBLE_DEVICES:-0}
+
+cd "$REPO_ROOT"
+python -m examples.ppo_vlm_vqa "$@"
+

--- a/examples/serve/README.md
+++ b/examples/serve/README.md
@@ -1,0 +1,62 @@
+# NovaRL vLLM Serving Guide
+
+This directory contains utilities for exporting RL-tuned checkpoints into the
+Hugging Face format and hosting them behind a high-throughput
+[vLLM](https://github.com/vllm-project/vllm) server.
+
+## 1. Export the policy to Hugging Face format
+
+NovaRL examples persist checkpoints as PyTorch state dictionaries by default.
+Convert them into the Hugging Face layout expected by vLLM (requires the
+`transformers` package):
+
+```bash
+python -m examples.export_policy_to_hf \
+  --checkpoint checkpoints/ppo_rlhf_single_turn/policy.pt \
+  --output-dir checkpoints/ppo_rlhf_single_turn_hf
+```
+
+The command infers the network dimensions from the saved weights and writes a
+standard `config.json` + `pytorch_model.bin` pair alongside
+`novarl_policy_metadata.json` for reference.
+
+## 2. Launch the vLLM server
+
+Install vLLM (e.g. `pip install vllm`) and run the OpenAI-compatible API server:
+
+```bash
+python -m examples.serve.serve_vllm \
+  --model checkpoints/ppo_rlhf_single_turn_hf \
+  --host 0.0.0.0 \
+  --port 8000 \
+  --tensor-parallel-size 1
+```
+
+The script is a thin wrapper around `vllm serve` and accepts the same
+performance-related flags such as `--max-model-len`, `--gpu-memory-utilization`
+and `--max-num-seqs` for tuning throughput.
+
+## 3. Measure throughput with batched rollouts
+
+With the server running, benchmark generation latency and throughput using the
+streaming rollout helper:
+
+```bash
+python -m examples.rollout_vllm_text \
+  --model checkpoints/ppo_rlhf_single_turn_hf \
+  --tensor-parallel-size 1 \
+  --batch-size 32 \
+  --num-batches 20 \
+  --warmup-batches 2 \
+  --perf-baseline-qps 1.0 \
+  --perf-target 10.0
+```
+
+The summary emitted at the end of the run reports average QPS, latency
+histograms and whether the measured throughput clears the configured speed-up
+target relative to a baseline implementation. Adjust the batch size or
+parallelism flags to explore the throughput vs. latency trade-off space. When
+the server is active you can point the `--model` flag to the exported directory
+for an in-process benchmark, or use the native `vllm serve` client tooling to
+exercise the OpenAI endpoint.
+

--- a/examples/serve/__init__.py
+++ b/examples/serve/__init__.py
@@ -1,0 +1,2 @@
+"""Utilities for running NovaRL checkpoints behind inference servers."""
+

--- a/examples/serve/serve_vllm.py
+++ b/examples/serve/serve_vllm.py
@@ -1,0 +1,123 @@
+"""Launch a vLLM OpenAI-compatible server for NovaRL checkpoints."""
+
+from __future__ import annotations
+
+import argparse
+import logging
+
+
+logger = logging.getLogger(__name__)
+
+
+def parse_args() -> argparse.Namespace:  # pragma: no cover - CLI wrapper
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--model",
+        required=True,
+        help="Path or Hugging Face identifier for the RL-tuned checkpoint exported in HF format.",
+    )
+    parser.add_argument(
+        "--tokenizer",
+        default=None,
+        help="Optional tokenizer path (defaults to the model identifier).",
+    )
+    parser.add_argument("--host", default="0.0.0.0", help="Host interface to bind")
+    parser.add_argument("--port", type=int, default=8000, help="Port to expose the OpenAI API")
+    parser.add_argument(
+        "--tensor-parallel-size",
+        type=int,
+        default=1,
+        help="Tensor parallel degree passed through to vLLM",
+    )
+    parser.add_argument(
+        "--max-model-len",
+        type=int,
+        default=None,
+        help="Optional sequence length override for vLLM",
+    )
+    parser.add_argument(
+        "--gpu-memory-utilization",
+        type=float,
+        default=0.9,
+        help="Target fraction of GPU memory to utilise",
+    )
+    parser.add_argument(
+        "--max-num-seqs",
+        type=int,
+        default=None,
+        help="Optional cap on concurrent sequences",
+    )
+    parser.add_argument(
+        "--log-level",
+        default="INFO",
+        choices=["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"],
+        help="Verbosity for the local logger as well as the vLLM server",
+    )
+    parser.add_argument(
+        "--disable-log-requests",
+        action="store_true",
+        help="Skip per-request logging to keep the output concise",
+    )
+    parser.add_argument(
+        "--served-model-name",
+        default=None,
+        help="Override the model name announced by the OpenAI-compatible endpoint",
+    )
+    parser.add_argument(
+        "--ssl-keyfile",
+        default=None,
+        help="Path to SSL key file when serving over HTTPS",
+    )
+    parser.add_argument(
+        "--ssl-certfile",
+        default=None,
+        help="Path to SSL certificate when serving over HTTPS",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:  # pragma: no cover - CLI entry point
+    args = parse_args()
+    logging.basicConfig(level=getattr(logging, args.log_level), format="[%(levelname)s] %(message)s")
+
+    try:
+        from vllm.engine.arg_utils import AsyncEngineArgs
+        from vllm.entrypoints.openai.api_server import run_server
+        from vllm.entrypoints.openai.cli_args import make_arg_parser as _make_arg_parser
+        from vllm.entrypoints.openai.cli_args import ServerArgs
+    except Exception as exc:  # pragma: no cover - import guard
+        raise ImportError(
+            "vLLM is required to serve checkpoints. Install it via `pip install vllm`."
+        ) from exc
+
+    # Reuse the upstream argument transformers so that behavioural parity with the
+    # ``vllm serve`` CLI is maintained. We manually stitch together the namespace to
+    # avoid re-parsing all command-line options.
+    parser = _make_arg_parser(argparse.ArgumentParser(add_help=False))
+    cli_args = parser.parse_args([])  # empty parse to get defaults
+
+    for key, value in vars(args).items():
+        setattr(cli_args, key.replace("-", "_"), value)
+
+    engine_args = AsyncEngineArgs.from_cli_args(cli_args)
+    server_args = ServerArgs.from_cli_args(cli_args)
+
+    if args.disable_log_requests:
+        server_args.log_requests = False
+
+    if args.served_model_name is not None:
+        server_args.served_model_name = args.served_model_name
+
+    logger.info(
+        "Starting vLLM server on %s:%s with model=%s tensor_parallel=%s",
+        args.host,
+        args.port,
+        args.model,
+        args.tensor_parallel_size,
+    )
+    run_server(engine_args, server_args)
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    main()
+


### PR DESCRIPTION
## Summary
- add Hugging Face policy wrapper plus an export CLI for converting NovaRL PPO checkpoints into HF format
- add a vLLM serving entry point and README guidance for benchmarking throughput on exported checkpoints
- publish single-node/multi-node launch recipes and a backend selection guide covering FSDP, ZeRO, and Megatron trade-offs

## Testing
- python -m compileall core/models/hf_policy.py examples/export_policy_to_hf.py examples/serve/serve_vllm.py examples/recipes/multi_node_wrapper.py

------
https://chatgpt.com/codex/tasks/task_e_68e4d0000d7c83328518da7e414bae96