### PR TITLE
Add MoE utilities, GRPO trainer, and async weight sync cadence

### DIFF
--- a/algos/__init__.py
+++ b/algos/__init__.py
@@ -1,5 +1,6 @@
 """Training algorithms."""
 
+from .grpo.trainer import GRPOTrainer
 from .ppo.trainer import PPOTrainer
 
-__all__ = ["PPOTrainer"]
+__all__ = ["GRPOTrainer", "PPOTrainer"]

--- a/algos/grpo/__init__.py
+++ b/algos/grpo/__init__.py
@@ -1,0 +1,6 @@
+"""GRPO training components."""
+
+from .trainer import GRPOGroupingConfig, GRPOTrainer
+
+__all__ = ["GRPOGroupingConfig", "GRPOTrainer"]
+

--- a/core/__init__.py
+++ b/core/__init__.py
@@ -3,10 +3,12 @@
 from .distributed import (  # noqa: F401
     DeepSpeedZeROConfig,
     FSDPStrategyPreset,
+    MoERouterConfig,
     MegatronAdapter,
     MegatronAdapterConfig,
     MegatronAdapterRegistry,
     NullMegatronAdapter,
+    ParallelLayout,
     get_default_fsdp_preset,
 )
 from .types import TrajectoryBatch
@@ -15,9 +17,11 @@ __all__ = [
     "TrajectoryBatch",
     "DeepSpeedZeROConfig",
     "FSDPStrategyPreset",
+    "MoERouterConfig",
     "MegatronAdapter",
     "MegatronAdapterConfig",
     "MegatronAdapterRegistry",
     "NullMegatronAdapter",
+    "ParallelLayout",
     "get_default_fsdp_preset",
 ]

--- a/core/distributed/__init__.py
+++ b/core/distributed/__init__.py
@@ -2,6 +2,7 @@
 
 from .deepspeed import DeepSpeedZeROConfig
 from .fsdp import FSDPStrategyPreset, get_default_fsdp_preset
+from .moe import MoERouterConfig, ParallelLayout
 from .megatron import (
     MegatronAdapter,
     MegatronAdapterConfig,
@@ -17,4 +18,6 @@ __all__ = [
     "MegatronAdapterRegistry",
     "NullMegatronAdapter",
     "get_default_fsdp_preset",
+    "MoERouterConfig",
+    "ParallelLayout",
 ]

--- a/core/distributed/moe.py
+++ b/core/distributed/moe.py
@@ -1,0 +1,145 @@
+"""Utilities describing MoE parallel layouts for Megatron/DeepSpeed."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Mapping, Optional
+
+
+@dataclass(slots=True)
+class ParallelLayout:
+    """Represents the combination of data, tensor, pipeline and expert parallelism."""
+
+    data_parallel_size: int = 1
+    tensor_parallel_size: int = 1
+    pipeline_parallel_size: int = 1
+    expert_parallel_size: int = 1
+
+    def world_size(self) -> int:
+        return (
+            self.data_parallel_size
+            * self.tensor_parallel_size
+            * self.pipeline_parallel_size
+            * self.expert_parallel_size
+        )
+
+    def validate(self, *, total_world_size: Optional[int] = None) -> None:
+        if self.data_parallel_size <= 0:
+            raise ValueError("data_parallel_size must be positive")
+        if self.tensor_parallel_size <= 0:
+            raise ValueError("tensor_parallel_size must be positive")
+        if self.pipeline_parallel_size <= 0:
+            raise ValueError("pipeline_parallel_size must be positive")
+        if self.expert_parallel_size <= 0:
+            raise ValueError("expert_parallel_size must be positive")
+        if total_world_size is not None and self.world_size() != total_world_size:
+            raise ValueError(
+                "Parallel layout world size mismatch: "
+                f"{self.world_size()} vs expected {total_world_size}"
+            )
+
+    @classmethod
+    def from_world_size(
+        cls,
+        total_world_size: int,
+        *,
+        tensor_parallel_size: int = 1,
+        pipeline_parallel_size: int = 1,
+        expert_parallel_size: int = 1,
+    ) -> "ParallelLayout":
+        if total_world_size <= 0:
+            raise ValueError("total_world_size must be positive")
+        denom = tensor_parallel_size * pipeline_parallel_size * expert_parallel_size
+        if denom <= 0 or total_world_size % denom != 0:
+            raise ValueError(
+                "World size must be divisible by tp*pp*ep: "
+                f"world={total_world_size} tp={tensor_parallel_size} pp={pipeline_parallel_size} ep={expert_parallel_size}"
+            )
+        data_parallel_size = total_world_size // denom
+        layout = cls(
+            data_parallel_size=data_parallel_size,
+            tensor_parallel_size=tensor_parallel_size,
+            pipeline_parallel_size=pipeline_parallel_size,
+            expert_parallel_size=expert_parallel_size,
+        )
+        layout.validate()
+        return layout
+
+    def describe(self) -> Dict[str, int]:
+        return {
+            "dp": self.data_parallel_size,
+            "tp": self.tensor_parallel_size,
+            "pp": self.pipeline_parallel_size,
+            "ep": self.expert_parallel_size,
+            "world": self.world_size(),
+        }
+
+    def megatron_kwargs(self) -> Dict[str, int]:
+        return {
+            "tensor_parallel_size": self.tensor_parallel_size,
+            "pipeline_parallel_size": self.pipeline_parallel_size,
+            "expert_parallel_size": self.expert_parallel_size,
+            "data_parallel_size": self.data_parallel_size,
+        }
+
+    def deepspeed_moe_dict(
+        self,
+        *,
+        num_experts: int,
+        top_k: int = 1,
+        capacity_factor: float = 1.25,
+        min_capacity: int = 4,
+        router_aux_loss_coef: float = 0.01,
+        router_jitter_noise: float = 0.0,
+        type_: str = "dropless",
+    ) -> Dict[str, object]:
+        return {
+            "enabled": True,
+            "type": type_,
+            "num_experts": num_experts,
+            "top_k": top_k,
+            "capacity_factor": capacity_factor,
+            "min_capacity": min_capacity,
+            "router_aux_loss_coef": router_aux_loss_coef,
+            "router_jitter_noise": router_jitter_noise,
+            "expert_parallel_size": self.expert_parallel_size,
+            "tensor_parallel_size": self.tensor_parallel_size,
+            "pipeline_parallel_size": self.pipeline_parallel_size,
+            "data_parallel_size": self.data_parallel_size,
+        }
+
+
+@dataclass(slots=True)
+class MoERouterConfig:
+    """Simple container for router hyper-parameters shared across backends."""
+
+    num_experts: int
+    top_k: int = 2
+    capacity_factor: float = 1.2
+    min_capacity: int = 4
+    router_aux_loss_coef: float = 0.01
+    router_jitter_noise: float = 0.0
+
+    def to_deepspeed(self, layout: ParallelLayout) -> Dict[str, object]:
+        return layout.deepspeed_moe_dict(
+            num_experts=self.num_experts,
+            top_k=self.top_k,
+            capacity_factor=self.capacity_factor,
+            min_capacity=self.min_capacity,
+            router_aux_loss_coef=self.router_aux_loss_coef,
+            router_jitter_noise=self.router_jitter_noise,
+        )
+
+    def to_megatron(self) -> Mapping[str, object]:
+        return {
+            "num_experts": self.num_experts,
+            "top_k": self.top_k,
+            "capacity_factor": self.capacity_factor,
+            "min_capacity": self.min_capacity,
+            "router_aux_loss_coef": self.router_aux_loss_coef,
+            "router_jitter_noise": self.router_jitter_noise,
+        }
+
+
+__all__ = ["MoERouterConfig", "ParallelLayout"]
+

--- a/core/utils/__init__.py
+++ b/core/utils/__init__.py
@@ -1,11 +1,21 @@
 """Utility helpers for NovaRL."""
 
+from .advantages import (
+    AdvantageEstimate,
+    AdvantageEstimator,
+    GAEAdvantageEstimator,
+    normalize_advantages,
+)
 from .stats import compute_discounted_returns, compute_gae, explained_variance
 from .timing import RateTracker
 
 __all__ = [
+    "AdvantageEstimate",
+    "AdvantageEstimator",
+    "GAEAdvantageEstimator",
     "RateTracker",
     "compute_discounted_returns",
     "compute_gae",
     "explained_variance",
+    "normalize_advantages",
 ]

--- a/core/utils/advantages.py
+++ b/core/utils/advantages.py
@@ -1,0 +1,82 @@
+"""Reusable advantage and return estimation utilities."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Protocol
+
+import torch
+
+from .stats import compute_gae
+
+
+@dataclass(slots=True)
+class AdvantageEstimate:
+    """Container bundling raw advantages with bootstrapped returns."""
+
+    advantages: torch.Tensor
+    returns: torch.Tensor
+
+
+class AdvantageEstimator(Protocol):
+    """Protocol describing advantage estimation strategies."""
+
+    def estimate(
+        self,
+        *,
+        rewards: torch.Tensor,
+        values: torch.Tensor,
+        dones: torch.Tensor,
+        bootstrap_value: torch.Tensor,
+    ) -> AdvantageEstimate:
+        """Return estimated advantages and bootstrapped returns."""
+
+
+class GAEAdvantageEstimator:
+    """Generalised Advantage Estimation helper.
+
+    The estimator expects time-major tensors with leading shape ``(T, B, ...)``.
+    ``values`` should contain the critic values for each transition and must
+    therefore have shape ``(T, B)`` while ``bootstrap_value`` corresponds to the
+    value prediction for the state following the final transition and must have
+    shape ``(B,)``.
+    """
+
+    def __init__(self, gamma: float = 0.99, lam: float = 0.95) -> None:
+        self.gamma = float(gamma)
+        self.lam = float(lam)
+
+    def estimate(
+        self,
+        *,
+        rewards: torch.Tensor,
+        values: torch.Tensor,
+        dones: torch.Tensor,
+        bootstrap_value: torch.Tensor,
+    ) -> AdvantageEstimate:
+        if values.dim() != rewards.dim():  # pragma: no cover - defensive
+            raise ValueError("values and rewards must have matching dimensionality")
+        bootstrap = torch.cat([values, bootstrap_value.unsqueeze(0)], dim=0)
+        advantages = compute_gae(
+            rewards=rewards,
+            values=bootstrap,
+            dones=dones,
+            gamma=self.gamma,
+            lam=self.lam,
+        )
+        returns = advantages + values
+        return AdvantageEstimate(advantages=advantages, returns=returns)
+
+
+def normalize_advantages(advantages: torch.Tensor, eps: float = 1e-8) -> torch.Tensor:
+    """Return z-scored advantages preserving the original tensor layout."""
+
+    if advantages.numel() == 0:  # pragma: no cover - defensive
+        return advantages
+    mean = advantages.mean()
+    std = advantages.std(unbiased=False)
+    return (advantages - mean) / (std + eps)
+
+
+__all__ = ["AdvantageEstimate", "AdvantageEstimator", "GAEAdvantageEstimator", "normalize_advantages"]
+

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,3 +7,5 @@ This directory hosts design documents and user guides for the NovaRL project.
 - [Choosing a distributed backend](choose_your_backend.md): compare FSDP,
   DeepSpeed ZeRO and Megatron tensor parallelism trade-offs when scaling RLHF
   workloads.
+- [Mixture-of-Experts quickstart](moe_demo.md): walk through the Megatron/DeepSpeed
+  layout helpers, GRPO integration, and the MoE demo controller flags.

--- a/docs/choose_your_backend.md
+++ b/docs/choose_your_backend.md
@@ -40,6 +40,10 @@ should consider when scaling PPO-style reinforcement learning pipelines.
 - **Megatron-style tensor parallelism**: Combine with RL policies that reuse
   inference-time tensor-parallel checkpoints (e.g. Llama or Falcon). Integrate
   with vLLM for serving by exporting shard metadata alongside weights.
+- **Megatron/DeepSpeed MoE**: Use `core.distributed.ParallelLayout` to lock in
+  compatible DP/TP/PP/EP factors and `MoERouterConfig` to emit the matching
+  DeepSpeed or Megatron router stanza.  This avoids mismatched expert parallel
+  groups when scaling Mixtral-style policies.
 
 ## Throughput vs. Memory Rule of Thumb
 

--- a/docs/moe_demo.md
+++ b/docs/moe_demo.md
@@ -1,0 +1,79 @@
+# Mixture-of-Experts quickstart
+
+This guide demonstrates how to exercise the lightweight MoE helpers that ship
+with NovaRL.  The demo runs on the same Hydra controller that drives the other
+examples and exposes flags for Megatron/DeepSpeed layout selection, algorithm
+choice (PPO or GRPO), and asynchronous weight synchronisation cadence.
+
+## Parallel layout helpers
+
+The new `ParallelLayout` and `MoERouterConfig` helpers live under
+`core.distributed`.  They encode the relationship between data-parallel (DP),
+tensor-parallel (TP), pipeline-parallel (PP), and expert-parallel (EP) sizes
+and can emit dictionaries suitable for Megatron-MoE launch arguments or the
+DeepSpeed-MoE JSON stanza.
+
+```python
+from core.distributed import ParallelLayout, MoERouterConfig
+
+layout = ParallelLayout.from_world_size(
+    total_world_size=8, tensor_parallel_size=2, pipeline_parallel_size=2, expert_parallel_size=2
+)
+router = MoERouterConfig(num_experts=8, top_k=2, capacity_factor=1.2)
+
+print(layout.describe())
+# {'dp': 1, 'tp': 2, 'pp': 2, 'ep': 2, 'world': 8}
+print(router.to_deepspeed(layout))
+```
+
+Megatron adapters now expose the same layout via `MegatronAdapterConfig.parallel_layout`,
+ensuring EP/TP/PP values remain consistent regardless of the launch backend.
+
+## Running the MoE demo
+
+The `examples/moe_demo.py` module creates a tiny Mixtral-style policy with a
+weighted routing layer.  It shares the synchronous rollout engine with the
+existing tutorials and consumes the new advantage interface so that PPO and
+GRPO may be swapped without touching the environment loop.
+
+Launch it through the common controller:
+
+```bash
+python scripts/train.py mode=moe_demo \
+  experiment.world_size=8 \
+  experiment.tensor_parallel_size=2 \
+  experiment.pipeline_parallel_size=2 \
+  experiment.expert_parallel_size=2 \
+  experiment.num_experts=4 \
+  experiment.algorithm=grpo
+```
+
+The demo prints a checklist summarising the DP/TP/PP/EP factors and router
+hyper-parameters before stepping through a handful of training iterations.
+
+## Algorithm options: PPO and GRPO
+
+Both PPO and GRPO are wired through a shared advantage/return estimator.  The
+`GAEAdvantageEstimator` lives in `core.utils.advantages` and provides
+standardised normalisation via `normalize_advantages`, eliminating duplicate
+z-scoring logic across trainers.
+
+Pick the optimiser from the Hydra config using `experiment.algorithm`.
+GRPO additionally accepts `experiment.grpo_group_size` which controls the
+relative baseline window.
+
+## Weight-sync cadence for async rollouts
+
+Asynchronous PPO experiments can now specify cadence in terms of update
+interval, maximum policy staleness, and an optional timeout.  The new
+`WeightSyncController` (defined in `examples/ppo_async.py`) replaces the raw
+modulo logic and ensures resumed runs, worker restarts, and staleness spikes
+force a broadcast when needed.  The relevant Hydra flags are:
+
+- `experiment.weight_sync_interval`
+- `experiment.weight_sync_max_staleness`
+- `experiment.weight_sync_timeout_s`
+
+Combine them according to your rollout topology—for example broadcast every
+4 updates but also whenever any worker lags by 6 policy versions, or at least
+every 30 seconds.

--- a/examples/moe_demo.py
+++ b/examples/moe_demo.py
@@ -1,0 +1,181 @@
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+
+import torch
+from torch import nn
+
+from algos.grpo import GRPOTrainer, GRPOGroupingConfig
+from algos.ppo import PPOTrainer
+from core.distributed import MoERouterConfig, ParallelLayout
+from core.utils.advantages import GAEAdvantageEstimator
+from core.utils.timing import RateTracker
+from engines.sync.sync_engine import SynchronousRolloutEngine
+from envs.prompt.toy import ToyPromptEnvironment
+from rewards.fake.basic import IdentityRewardManager
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class MoEDemoConfig:
+    batch_size: int = 4
+    horizon: int = 4
+    observation_dim: int = 16
+    action_dim: int = 6
+    hidden_size: int = 64
+    total_iterations: int = 6
+    learning_rate: float = 3e-3
+    algorithm: str = "ppo"
+    grpo_group_size: int = 2
+    num_experts: int = 4
+    top_k: int = 2
+    capacity_factor: float = 1.25
+    world_size: int = 8
+    tensor_parallel_size: int = 2
+    pipeline_parallel_size: int = 2
+    expert_parallel_size: int = 2
+    gamma: float = 0.99
+    lam: float = 0.95
+
+
+class TinyMoELayer(nn.Module):
+    def __init__(self, hidden_size: int, num_experts: int, top_k: int) -> None:
+        super().__init__()
+        self.top_k = top_k
+        self.router = nn.Linear(hidden_size, num_experts)
+        self.experts = nn.ModuleList(
+            [
+                nn.Sequential(
+                    nn.Linear(hidden_size, hidden_size),
+                    nn.GELU(),
+                    nn.Linear(hidden_size, hidden_size),
+                )
+                for _ in range(num_experts)
+            ]
+        )
+
+    def forward(self, inputs: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+        logits = self.router(inputs)
+        weights = torch.softmax(logits, dim=-1)
+        top_values, top_indices = torch.topk(weights, k=self.top_k, dim=-1)
+        mask = torch.zeros_like(weights)
+        mask.scatter_(-1, top_indices, 1.0)
+        masked_weights = weights * mask
+        masked_weights = masked_weights / (masked_weights.sum(dim=-1, keepdim=True) + 1e-9)
+        expert_outputs = torch.stack([expert(inputs) for expert in self.experts], dim=1)
+        combined = torch.einsum("b e, b e h -> b h", masked_weights, expert_outputs)
+        return combined, weights
+
+
+class TinyMoEPolicy(nn.Module):
+    def __init__(
+        self,
+        observation_dim: int,
+        action_dim: int,
+        hidden_size: int,
+        num_experts: int,
+        top_k: int,
+    ) -> None:
+        super().__init__()
+        self.encoder = nn.Sequential(
+            nn.Linear(observation_dim, hidden_size),
+            nn.GELU(),
+        )
+        self.moe = TinyMoELayer(hidden_size, num_experts, top_k)
+        self.norm = nn.LayerNorm(hidden_size)
+        self.policy_head = nn.Linear(hidden_size, action_dim)
+        self.value_head = nn.Linear(hidden_size, 1)
+
+    def forward(self, observations: torch.Tensor) -> dict[str, torch.Tensor]:
+        encoded = self.encoder(observations)
+        moe_out, router = self.moe(encoded)
+        hidden = self.norm(moe_out + encoded)
+        logits = self.policy_head(hidden)
+        value = self.value_head(hidden)
+        return {"logits": logits, "value": value, "router_probs": router}
+
+
+def _build_trainer(cfg: MoEDemoConfig, policy: nn.Module, optimizer: torch.optim.Optimizer):
+    algorithm = cfg.algorithm.lower()
+    if algorithm == "ppo":
+        return PPOTrainer(policy=policy, optimizer=optimizer)
+    if algorithm == "grpo":
+        grouping = GRPOGroupingConfig(group_size=cfg.grpo_group_size)
+        return GRPOTrainer(policy=policy, optimizer=optimizer, grouping=grouping)
+    raise ValueError(f"Unsupported algorithm '{cfg.algorithm}'")
+
+
+def _describe_parallel_layout(cfg: MoEDemoConfig) -> tuple[ParallelLayout, MoERouterConfig]:
+    layout = ParallelLayout.from_world_size(
+        total_world_size=cfg.world_size,
+        tensor_parallel_size=cfg.tensor_parallel_size,
+        pipeline_parallel_size=cfg.pipeline_parallel_size,
+        expert_parallel_size=cfg.expert_parallel_size,
+    )
+    router = MoERouterConfig(
+        num_experts=cfg.num_experts,
+        top_k=cfg.top_k,
+        capacity_factor=cfg.capacity_factor,
+    )
+    return layout, router
+
+
+def main(cfg: MoEDemoConfig | None = None) -> None:
+    logging.basicConfig(level=logging.INFO, format="[%(levelname)s] %(message)s")
+    cfg = cfg or MoEDemoConfig()
+    layout, router = _describe_parallel_layout(cfg)
+    layout.validate(total_world_size=cfg.world_size)
+    logger.info("MoE parallel layout: %s", layout.describe())
+    logger.info("Router config: num_experts=%d top_k=%d capacity=%.2f", router.num_experts, router.top_k, router.capacity_factor)
+
+    device = torch.device("cpu")
+    env = ToyPromptEnvironment(
+        batch_size=cfg.batch_size,
+        observation_dim=cfg.observation_dim,
+        action_dim=cfg.action_dim,
+        max_turns=cfg.horizon,
+        device=device,
+    )
+    policy = TinyMoEPolicy(
+        cfg.observation_dim,
+        cfg.action_dim,
+        cfg.hidden_size,
+        cfg.num_experts,
+        cfg.top_k,
+    ).to(device)
+    optimizer = torch.optim.AdamW(policy.parameters(), lr=cfg.learning_rate)
+    estimator = GAEAdvantageEstimator(gamma=cfg.gamma, lam=cfg.lam)
+
+    rollout_engine = SynchronousRolloutEngine(
+        env=env,
+        policy=policy,
+        reward_manager=IdentityRewardManager(),
+        horizon=cfg.horizon,
+        advantage_estimator=estimator,
+    )
+    trainer = _build_trainer(cfg, policy, optimizer)
+    rate_tracker = RateTracker(window_seconds=30.0)
+
+    for iteration in range(cfg.total_iterations):
+        batch = rollout_engine.generate()
+        metrics = trainer.step(batch)
+        completed = batch.completed_episodes()
+        rate_tracker.update(completed)
+        logger.info(
+            "iter=%d reward=%.3f kl=%.4f entropy=%.3f eps/s=%.2f",
+            iteration,
+            metrics.get("reward_mean", 0.0),
+            metrics.get("kl", 0.0),
+            metrics.get("entropy", 0.0),
+            rate_tracker.rate(),
+        )
+
+
+if __name__ == "__main__":
+    main()
+
+
+__all__ = ["MoEDemoConfig", "TinyMoEPolicy", "main"]
+

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -7,6 +7,8 @@ from omegaconf import DictConfig
 
 from examples.minimal_ppo_sync import ExperimentConfig
 from examples.minimal_ppo_sync import main as run_sync_example
+from examples.moe_demo import MoEDemoConfig
+from examples.moe_demo import main as run_moe_demo
 from examples.ppo_async import AsyncExperimentConfig, run_async_training
 
 logger = logging.getLogger(__name__)
@@ -21,6 +23,9 @@ def main(cfg: DictConfig) -> None:
     elif mode == "async":
         exp_cfg = AsyncExperimentConfig(**cfg.get("experiment", {}))
         run_async_training(exp_cfg)
+    elif mode == "moe_demo":
+        exp_cfg = MoEDemoConfig(**cfg.get("experiment", {}))
+        run_moe_demo(exp_cfg)
     else:
         raise ValueError(f"Unsupported trainer mode: {mode}")
 

--- a/tests/test_advantages.py
+++ b/tests/test_advantages.py
@@ -1,0 +1,33 @@
+import torch
+
+from core.utils.advantages import GAEAdvantageEstimator, normalize_advantages
+from core.utils.stats import compute_gae
+
+
+def test_gae_estimator_matches_reference():
+    torch.manual_seed(0)
+    rewards = torch.randn(5, 3)
+    values = torch.randn(5, 3)
+    bootstrap = torch.randn(3)
+    estimator = GAEAdvantageEstimator(gamma=0.9, lam=0.8)
+    result = estimator.estimate(
+        rewards=rewards,
+        values=values,
+        dones=torch.zeros_like(rewards),
+        bootstrap_value=bootstrap,
+    )
+    reference = compute_gae(
+        rewards=rewards,
+        values=torch.cat([values, bootstrap.unsqueeze(0)], dim=0),
+        dones=torch.zeros_like(rewards),
+        gamma=0.9,
+        lam=0.8,
+    )
+    assert torch.allclose(result.advantages, reference)
+    assert torch.allclose(result.returns, reference + values)
+
+
+def test_normalize_advantages_zero_mean():
+    data = torch.tensor([1.0, 2.0, 3.0])
+    normalized = normalize_advantages(data)
+    assert torch.isclose(normalized.mean(), torch.tensor(0.0), atol=1e-6)

--- a/tests/test_grpo.py
+++ b/tests/test_grpo.py
@@ -1,0 +1,59 @@
+import torch
+from torch import nn
+
+from algos.grpo import GRPOGroupingConfig, GRPOTrainer
+from core.types import TrajectoryBatch
+
+
+class _TinyPolicy(nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.linear = nn.Linear(3, 2)
+
+    def forward(self, observations: torch.Tensor) -> dict[str, torch.Tensor]:
+        hidden = self.linear(observations)
+        logits = hidden
+        value = hidden.sum(dim=-1, keepdim=True)
+        return {"logits": logits, "value": value}
+
+
+def _make_batch(returns: torch.Tensor) -> TrajectoryBatch:
+    t, b = returns.shape
+    observations = torch.randn(t, b, 3)
+    actions = torch.zeros(t, b, dtype=torch.long)
+    log_probs = torch.zeros(t, b)
+    rewards = torch.zeros(t, b)
+    dones = torch.zeros(t, b)
+    values = torch.zeros(t, b)
+    advantages = torch.zeros(t, b)
+    return TrajectoryBatch(
+        observations=observations,
+        actions=actions,
+        log_probs=log_probs,
+        rewards=rewards,
+        dones=dones,
+        values=values,
+        advantages=advantages,
+        returns=returns,
+    )
+
+
+def test_group_relative_advantages_zero_mean():
+    policy = _TinyPolicy()
+    optimizer = torch.optim.Adam(policy.parameters(), lr=1e-3)
+    trainer = GRPOTrainer(policy=policy, optimizer=optimizer, grouping=GRPOGroupingConfig(group_size=2))
+    returns = torch.tensor([[1.0, 4.0, 5.0, 9.0]])
+    adv = trainer._group_relative_advantages(returns.flatten())
+    assert torch.isclose(adv[:2].sum(), torch.tensor(0.0), atol=1e-6)
+    assert torch.isclose(adv[2:].sum(), torch.tensor(0.0), atol=1e-6)
+
+
+def test_grpo_step_runs():
+    policy = _TinyPolicy()
+    optimizer = torch.optim.Adam(policy.parameters(), lr=1e-3)
+    trainer = GRPOTrainer(policy=policy, optimizer=optimizer, grouping=GRPOGroupingConfig(group_size=2))
+    returns = torch.tensor([[1.0, 2.0, 3.0, 4.0]], dtype=torch.float32)
+    batch = _make_batch(returns)
+    metrics = trainer.step(batch)
+    assert "loss" in metrics
+    assert metrics["advantage_norm"] >= 0.0

--- a/tests/test_moe_layout.py
+++ b/tests/test_moe_layout.py
@@ -1,0 +1,24 @@
+import pytest
+
+from core.distributed import MoERouterConfig, ParallelLayout
+
+
+def test_parallel_layout_from_world_size():
+    layout = ParallelLayout.from_world_size(
+        total_world_size=8, tensor_parallel_size=2, pipeline_parallel_size=2, expert_parallel_size=2
+    )
+    assert layout.data_parallel_size == 1
+    assert layout.describe()["world"] == 8
+
+
+def test_parallel_layout_validation_failure():
+    with pytest.raises(ValueError):
+        ParallelLayout.from_world_size(total_world_size=7, tensor_parallel_size=2)
+
+
+def test_moe_router_to_deepspeed():
+    layout = ParallelLayout.from_world_size(total_world_size=8, tensor_parallel_size=2, expert_parallel_size=2)
+    router = MoERouterConfig(num_experts=4, top_k=2, capacity_factor=1.3)
+    cfg = router.to_deepspeed(layout)
+    assert cfg["num_experts"] == 4
+    assert cfg["expert_parallel_size"] == 2

--- a/tests/test_weight_sync.py
+++ b/tests/test_weight_sync.py
@@ -1,0 +1,24 @@
+import time
+
+from examples.ppo_async import WeightSyncCadence, WeightSyncController
+
+
+def test_weight_sync_interval_triggers():
+    controller = WeightSyncController(WeightSyncCadence(interval=3))
+    assert controller.should_sync(3, [])
+    controller.mark_synced(3)
+    assert not controller.should_sync(4, [0, 1])
+    assert controller.should_sync(6, [])
+
+
+def test_weight_sync_timeout():
+    controller = WeightSyncController(WeightSyncCadence(interval=100, timeout_s=0.01))
+    controller.mark_synced(0)
+    time.sleep(0.02)
+    assert controller.should_sync(1, [])
+
+
+def test_weight_sync_staleness():
+    controller = WeightSyncController(WeightSyncCadence(interval=10, max_staleness=5))
+    controller.mark_synced(0)
+    assert controller.should_sync(1, [6])


### PR DESCRIPTION
## Summary
- add a reusable GAE-based advantage interface and integrate it into PPO and the rollout engine
- introduce a GRPO trainer alongside a tiny MoE demo plus Megatron/DeepSpeed MoE layout helpers and docs
- extend the async PPO example with a weight sync controller that supports staleness and timeout cadences

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68e4d91a946483328e45e2845a5c4aae